### PR TITLE
Fix/sidebar header glitch

### DIFF
--- a/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
@@ -11,7 +11,7 @@
               android:gravity="bottom"
               android:orientation="vertical"
               android:paddingBottom="@dimen/activity_vertical_margin"
-              android:paddingLeft="@dimen/activity_horizontal_margin"
+              android:paddingLeft="25dp"
               android:paddingRight="@dimen/activity_horizontal_margin"
               android:paddingTop="@dimen/activity_vertical_margin"
               android:theme="@style/ThemeOverlay.AppCompat.Dark">

--- a/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
@@ -31,6 +31,7 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
 
     <TextView
+        android:autoLink="web"
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
@@ -4,6 +4,7 @@
   ~ National Aeronautics and Space Administration. All Rights Reserved.
   -->
 
+<!-- android:paddingLeft is a constant to avoid padding inconsistencies in landscape mode -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
               android:layout_height="@dimen/nav_header_height"

--- a/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-examples/src/main/res/layout/nav_drawer_header.xml
@@ -33,6 +33,7 @@
     <TextView
         android:autoLink="web"
         android:id="@+id/textView"
+        android:textColorLink="@android:color/white"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="https://github.com/NASAWorldWind/WorldWindAndroid"/>

--- a/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
@@ -11,7 +11,7 @@
               android:gravity="bottom"
               android:orientation="vertical"
               android:paddingBottom="@dimen/activity_vertical_margin"
-              android:paddingLeft="@dimen/activity_horizontal_margin"
+              android:paddingLeft="25dp"
               android:paddingRight="@dimen/activity_horizontal_margin"
               android:paddingTop="@dimen/activity_vertical_margin"
               android:theme="@style/ThemeOverlay.AppCompat.Dark">

--- a/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
@@ -31,6 +31,7 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
 
     <TextView
+        android:autoLink="web"
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
@@ -4,6 +4,7 @@
   ~ National Aeronautics and Space Administration. All Rights Reserved.
   -->
 
+<!-- android:paddingLeft is a constant to avoid padding inconsistencies in landscape mode -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
               android:layout_height="@dimen/nav_header_height"

--- a/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
+++ b/worldwind-tutorials/src/main/res/layout/nav_drawer_header.xml
@@ -33,6 +33,7 @@
     <TextView
         android:autoLink="web"
         android:id="@+id/textView"
+        android:textColorLink="@android:color/white"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="https://github.com/NASAWorldWind/WorldWindAndroid"/>


### PR DESCRIPTION
The drawer/sidebar header left padding has been made constant. This avoids the glitch happening in #108 

The URL is now a hyperlink that directs the user to the repository.