### PR TITLE
Enable SNAPSHOT artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ script:
 
 # Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:
+  # Publish SNAPSHOT artifacts to oss.jfrog.org
+  - provider: script
+    script: ./gradlew worldwind:artifactoryPublish --stacktrace
+    skip_cleanup: true
+    on:
+      branch: develop
   # Publish release artifacts to Bintray/JCenter
   - provider: script
     script: ./gradlew worldwind:bintrayUpload --stacktrace

--- a/worldwind/build.gradle
+++ b/worldwind/build.gradle
@@ -106,7 +106,7 @@ artifactory {
         repository {
             repoKey = 'oss-snapshot-local'
             username = System.getenv('BINTRAY_USER')
-            password = System.getenv('OJO_API_KEY')
+            password = System.getenv('BINTRAY_API_KEY')
         }
         defaults {
             publications('bintray')


### PR DESCRIPTION
Changes for SNAPSHOT publishing to oss.jfrog.org

- See issue #104 

- Corrected oss.jfrog.org credentials: BINTRAY_USER and BINTRAY_API_KEY

- Added Travis CI deploy directive which publishes to oss.jfrog.org on develop branch builds 