### PR TITLE
Updated Tile.mustSubdivide to address tile count near the poles

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/BlueMarbleLandsatLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/BlueMarbleLandsatLayer.java
@@ -85,7 +85,7 @@ public class BlueMarbleLandsatLayer extends RenderableLayer implements TileFacto
 
     @Override
     public Tile createTile(Sector sector, Level level, int row, int column) {
-        double radiansPerPixel = level.texelHeight;
+        double radiansPerPixel = Math.toRadians(level.tileDelta) / level.tileHeight;
         double metersPerPixel = radiansPerPixel * WorldWind.WGS84_SEMI_MAJOR_AXIS;
 
         if (metersPerPixel < 2.0e3) { // switch to Landsat at 2km resolution

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
@@ -48,11 +48,6 @@ public class Level {
     public final int tileHeight;
 
     /**
-     * The size of pixels or elevation cells within this level, in radians per pixel (or per cell).
-     */
-    public final double texelHeight;
-
-    /**
      * Constructs a Level within a {@link LevelSet}. Applications typically do not interact with this class.
      *
      * @param parent      the level set that this level is a member of
@@ -77,7 +72,6 @@ public class Level {
         this.tileDelta = tileDelta;
         this.tileWidth = parent.tileWidth;
         this.tileHeight = parent.tileHeight;
-        this.texelHeight = Math.toRadians(tileDelta) / parent.tileHeight;
     }
 
     /**

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -48,6 +48,23 @@ public class Tile {
     public final String tileKey;
 
     /**
+     * A factor expressing the size of a pixel or elevation cell at the center of this tile, in radians per pixel (or
+     * cell).
+     * <p>
+     * Texel size in meters is computed as <code>(tileDelta / tileWidth) * cos(lat) * R</code>, where lat is the
+     * centroid latitude and R is the globe's equatorial radius. This is derived by considering that texels are laid out
+     * continuously on the arc of constant latitude connecting the tile's east and west edges and passing through its
+     * centroid. The radii for the corresponding circle of constant latitude is <code>cos(lat) * R</code>, and the arc
+     * length is therefore <code>tileDelta * cos(lat) * R</code>. The size of a texel along this arc is then found by
+     * dividing by the number of texels along that arc, defined by the property Level.tileWidth.
+     * <p>
+     * This property stores the constant part of the texel size computation, <code>(tileDelta / tileWidth) *
+     * cos(lat)</code>, leaving the globe-dependant variable <code>R</code> to be incorporated by the globe attached to
+     * the RenderContext.
+     */
+    protected double texelSizeFactor;
+
+    /**
      * The tile's Cartesian bounding box.
      */
     protected BoundingBox extent;
@@ -90,6 +107,7 @@ public class Tile {
         this.row = row;
         this.column = column;
         this.tileKey = level.levelNumber + "." + row + "." + column;
+        this.texelSizeFactor = Math.toRadians(level.tileDelta / level.tileWidth) * Math.cos(Math.toRadians(sector.centroidLatitude()));
     }
 
     /**
@@ -268,7 +286,7 @@ public class Tile {
      */
     public boolean mustSubdivide(RenderContext rc, double detailFactor) {
         this.distanceToCamera = this.distanceToCamera(rc);
-        double texelSize = this.level.texelHeight * rc.globe.getEquatorialRadius();
+        double texelSize = this.texelSizeFactor * rc.globe.getEquatorialRadius();
         double pixelSize = rc.pixelSizeAtDistance(this.distanceToCamera);
         double densityFactor = 1.0;
 


### PR DESCRIPTION
Modified the tile selection algorithm to choose tile detail based on a tile's centroid width, rather than its height. Since the tile width varies with latitude and captures tile distortion near the poles, tile count near the poles remains reasonable. This provides an immediate solution to OutOfMemoryErrors when the camera is near the poles, and closes #116.