### PR TITLE
Established support for depth-only drawing from a specified perspective

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawContext.java
@@ -65,7 +65,7 @@ public class DrawContext {
 
     private int elementArrayBufferId;
 
-    private Framebuffer surfaceFramebuffer;
+    private Framebuffer scratchFramebuffer;
 
     private BufferObject unitSquareBuffer;
 
@@ -103,7 +103,7 @@ public class DrawContext {
         this.textureUnit = GLES20.GL_TEXTURE0;
         this.arrayBufferId = 0;
         this.elementArrayBufferId = 0;
-        this.surfaceFramebuffer = null;
+        this.scratchFramebuffer = null;
         this.unitSquareBuffer = null;
         Arrays.fill(this.textureId, 0);
     }
@@ -155,16 +155,34 @@ public class DrawContext {
         }
     }
 
-    public Framebuffer surfaceFramebuffer() {
-        if (this.surfaceFramebuffer != null) {
-            return this.surfaceFramebuffer;
+    /**
+     * Returns an OpenGL framebuffer object suitable for offscreen drawing. The framebuffer has a 32-bit color buffer
+     * and a 32-bit depth buffer, both attached as OpenGL texture 2D objects.
+     * <p>
+     * The framebuffer may be used by any drawable and for any purpose. However, the draw context makes no guarantees
+     * about the framebuffer's contents. Drawables must clear the framebuffer before use, and must assume its contents
+     * may be modified by another drawable, either during the current frame or in a subsequent frame.
+     * <p>
+     * The OpenGL framebuffer object is created on first use and cached. Subsequent calls to this method return the
+     * cached buffer object.
+     *
+     * @return the draw context's scratch OpenGL framebuffer object
+     */
+    public Framebuffer scratchFramebuffer() {
+        if (this.scratchFramebuffer != null) {
+            return this.scratchFramebuffer;
         }
 
         Framebuffer framebuffer = new Framebuffer();
-        Texture colorAttachment = new Texture(1024, 1024, GLES20.GL_RGBA);
+        Texture colorAttachment = new Texture(1024, 1024, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE);
+        Texture depthAttachment = new Texture(1024, 1024, GLES20.GL_DEPTH_COMPONENT, GLES20.GL_UNSIGNED_INT);
+        // TODO consider modifying Texture's tex parameter behavior in order to make this unnecessary
+        depthAttachment.setTexParameter(GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
+        depthAttachment.setTexParameter(GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
         framebuffer.attachTexture(this, colorAttachment, GLES20.GL_COLOR_ATTACHMENT0);
+        framebuffer.attachTexture(this, depthAttachment, GLES20.GL_DEPTH_ATTACHMENT);
 
-        return (this.surfaceFramebuffer = framebuffer);
+        return (this.scratchFramebuffer = framebuffer);
     }
 
     /**
@@ -292,6 +310,8 @@ public class DrawContext {
      * <p/>
      * The OpenGL buffer object is created on first use and cached. Subsequent calls to this method return the cached
      * buffer object.
+     *
+     * @return the draw context's unit square OpenGL buffer object
      */
     public BufferObject unitSquareBuffer() {
         if (this.unitSquareBuffer != null) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawableSurfaceShape.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawableSurfaceShape.java
@@ -109,15 +109,16 @@ public class DrawableSurfaceShape implements Drawable {
         int shapeCount = 0;
 
         try {
-            Framebuffer framebuffer = dc.surfaceFramebuffer();
+            Framebuffer framebuffer = dc.scratchFramebuffer();
             if (!framebuffer.bindFramebuffer(dc)) {
                 return 0; // framebuffer failed to bind
             }
 
-            // Clear the framebuffer.
+            // Clear the framebuffer and disable the depth test.
             Texture colorAttachment = framebuffer.getAttachedTexture(GLES20.GL_COLOR_ATTACHMENT0);
             GLES20.glViewport(0, 0, colorAttachment.getWidth(), colorAttachment.getHeight());
             GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+            GLES20.glDisable(GLES20.GL_DEPTH_TEST);
 
             // Use the draw context's pick mode.
             this.drawState.program.enablePickMode(dc.pickMode);
@@ -173,6 +174,7 @@ public class DrawableSurfaceShape implements Drawable {
             // Restore the default World Wind OpenGL state.
             dc.bindFramebuffer(0);
             GLES20.glViewport(dc.viewport.x, dc.viewport.y, dc.viewport.width, dc.viewport.height);
+            GLES20.glEnable(GLES20.GL_DEPTH_TEST);
             GLES20.glLineWidth(1);
         }
 
@@ -188,7 +190,7 @@ public class DrawableSurfaceShape implements Drawable {
             return; // terrain vertex attribute failed to bind
         }
 
-        Texture colorAttachment = dc.surfaceFramebuffer().getAttachedTexture(GLES20.GL_COLOR_ATTACHMENT0);
+        Texture colorAttachment = dc.scratchFramebuffer().getAttachedTexture(GLES20.GL_COLOR_ATTACHMENT0);
         if (!colorAttachment.bindTexture(dc)) {
             return; // framebuffer texture failed to bind
         }

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/Texture.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/Texture.java
@@ -27,6 +27,8 @@ public class Texture implements RenderResource {
 
     protected int textureFormat;
 
+    protected int textureType;
+
     protected int textureByteCount;
 
     protected Matrix3 texCoordTransform = new Matrix3();
@@ -53,12 +55,13 @@ public class Texture implements RenderResource {
         this.textureWidth = width;
         this.textureHeight = height;
         this.textureFormat = format;
+        this.textureType = type;
         this.textureByteCount = estimateByteCount(width, height, format, type);
         this.texCoordTransform.setToVerticalFlip();
         this.imageBitmap = bitmap;
     }
 
-    public Texture(int width, int height, int format) {
+    public Texture(int width, int height, int format, int type) {
         if (width < 0 || height < 0) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "Texture", "constructor", "invalidWidthOrHeight"));
@@ -67,6 +70,7 @@ public class Texture implements RenderResource {
         this.textureWidth = width;
         this.textureHeight = height;
         this.textureFormat = format;
+        this.textureType = type;
         this.textureByteCount = estimateByteCount(width, height, format, GLES20.GL_UNSIGNED_BYTE);
         this.texCoordTransform.setToIdentity();
     }
@@ -168,7 +172,7 @@ public class Texture implements RenderResource {
         // Allocate texture memory for the OpenGL texture 2D object. The texture memory is initialized with 0.
         GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0 /*level*/,
             this.textureFormat, this.textureWidth, this.textureHeight, 0 /*border*/,
-            this.textureFormat, GLES20.GL_UNSIGNED_BYTE, null /*pixels*/);
+            this.textureFormat, this.textureType, null /*pixels*/);
     }
 
     protected void loadTexImage(DrawContext dc, Bitmap bitmap) {
@@ -189,6 +193,10 @@ public class Texture implements RenderResource {
                 "Exception attempting to load texture image \'" + bitmap + "\'", e);
         }
     }
+
+    // TODO refactor setTexParameters to apply all configured tex parameters
+    // TODO apply defaults only when no parameter is configured
+    // TODO consider simplifying the defaults and requiring that layers/shapes specify what they want
 
     protected void setTexParameters(DrawContext dc) {
         int param;
@@ -255,6 +263,10 @@ public class Texture implements RenderResource {
                         break;
                 }
                 break;
+            case GLES20.GL_UNSIGNED_INT:
+                bytesPerRow = widthPow2 * 4; // 32 bits per pixel
+                break;
+            case GLES20.GL_UNSIGNED_SHORT:
             case GLES20.GL_UNSIGNED_SHORT_5_6_5:
             case GLES20.GL_UNSIGNED_SHORT_4_4_4_4:
             case GLES20.GL_UNSIGNED_SHORT_5_5_5_1:


### PR DESCRIPTION
- Added a depth attachment to DrawContext's scratch framebuffer
- Adjusted Texture to accomodate depth texture's format and type
- Adjusted surface shapes to handle the presences of a depth buffer during offscreen drawing
- Closes #132
- Closes #133