### PR TITLE
Modified OmnidirectionalSightline to handle extreme range values

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawableSightline.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawableSightline.java
@@ -19,7 +19,7 @@ public class DrawableSightline implements Drawable {
 
     public Matrix4 centerTransform = new Matrix4();
 
-    public double range;
+    public float range;
 
     public Color visibleColor = new Color(0, 0, 0, 0);
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/SightlineProgram.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/SightlineProgram.java
@@ -69,8 +69,8 @@ public class SightlineProgram extends ShaderProgram {
         GLES20.glUniformMatrix4fv(this.slpMatrixId, 2, false, this.array, 0);
     }
 
-    public void loadRange(double range) {
-        GLES20.glUniform1f(this.rangeId, (float) range);
+    public void loadRange(float range) {
+        GLES20.glUniform1f(this.rangeId, range);
     }
 
     public void loadColor(Color visibleColor, Color occludedColor) {


### PR DESCRIPTION
- Setting range to zero displays nothing
- Setting range to infinity applies the sightline's overlay to the entire globe