### PR TITLE
Updated Travis CI release changelog generation

### DIFF
--- a/travis/changelog.sh
+++ b/travis/changelog.sh
@@ -9,7 +9,7 @@ echo "######Released on $(date '+%Y-%m-%d')"
 GITHUB_API_URL="https://api.github.com/repos/${TRAVIS_REPO_SLUG}"
 MILESTONE_ARRAY=( \
     $(curl --silent "${GITHUB_API_URL}/milestones?state=all" \
-    | jq --arg title "${TRAVIS_TAG}" '.[] | select(.title == $title) | .number') \
+    | jq --arg title "${TRAVIS_TAG}" '.[] | select(.title | contains($title)) | .number') \
     ) > /dev/null
 
 # When GitHub has a milestone matching the Git tag, write milestone related information to the change log
@@ -17,16 +17,15 @@ if [[ "${#MILESTONE_ARRAY[@]}" -ne 0 ]]; then
     # Write the milestone description to the change log
     MILESTONE_DESCRIPTION=( \
         $(curl --silent "${GITHUB_API_URL}/milestones/${MILESTONE_ARRAY[0]}" \
-        | jq .description) \
+        | jq .description --raw-output) \
         ) > /dev/null
-    MILESTONE_DESCRIPTION=${MILESTONE_DESCRIPTION[*]#\"}
-    echo ${MILESTONE_DESCRIPTION[*]%\"}
+    echo "${MILESTONE_DESCRIPTION[*]}"
 
     # Write the milestone's associated issues to the change log with each issue on a separate line with the issue
     # title, issue number, and a link to the issue on GitHub.com, all in markdown format: .title ([#.number](.html_url))
     ISSUE_ARRAY=$(curl --silent "${GITHUB_API_URL}/issues?state=all&milestone=${MILESTONE_ARRAY[0]}" | jq -c '.[] | [.title, .number, .html_url]') >> /dev/null
     while read line
     do
-        echo ${line} | sed 's#\["\(.*\)",\(.*\),"\(.*\)"\]#- \1 ([\#\2](\3))#'
+        echo ${line} | sed 's#\["\(.*\)",\(.*\),"\(.*\)"\]#- \1 [\#\2](\3)#'
     done <<< "${ISSUE_ARRAY[*]}"
 fi


### PR DESCRIPTION
- Handle GitHub milestone titles that containing the release tag, but don't match it exactly (e.g. WWA v0.7.0)
- Repair and simplify GitHub milestone description
- Remove unnecessary parenthesis around GitHub issue links
- Relates to #139 