### PR TITLE
Fix broken logo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://worldwind.arc.nasa.gov/css/images/nasa-logo.svg" height="100"/>
+<img src="https://worldwind.arc.nasa.gov/img/nasa-logo.svg" height="100"/>
 
 # WorldWind Android
 


### PR DESCRIPTION
Closes [101](https://github.com/NASAWorldWind/NASAWorldWind.github.io/issues/101) from NASAWorldWind.github.io repo

There was a broken logo reference in the repo's read me file (since the structure of our site has been changed). This is being fixed across all repos. 