### PR TITLE
Publish API documentation to gh-pages on every push to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,13 @@ deploy:
     skip_cleanup: true
     on:
       branch: develop
+  # Publish API documentation to GitHub Pages
+  - provider: pages
+    github_token: $GITHUB_API_KEY
+    local_dir: worldwind/build/outputs/doc/javadoc
+    skip_cleanup: true
+    on:
+      branch: develop
   # Publish release artifacts to Bintray/JCenter
   - provider: script
     script: ./gradlew worldwind:bintrayUpload --stacktrace


### PR DESCRIPTION
### Description of the Change

Publish the WorldWindAndroid API documentation to the built-in GitHub pages site after every push to develop. The resultant documentation is immediately available online and always up-to-date. The WorldWind website links to this documentation from the Android documentation page.

https://NASAWorldWind.github.io/WorldWindAndroid

### Why Should This Be In Core?

See description.

### Benefits

See description.

### Potential Drawbacks

None.

### Applicable Issues

Closes #169 