### PR TITLE
Moved WorldWindAndroid tutorial data to a more permanent location

### DIFF
--- a/worldwind-tutorials/src/main/assets/surface_image_tutorial.html
+++ b/worldwind-tutorials/src/main/assets/surface_image_tutorial.html
@@ -53,7 +53,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
 
         // Configure a Surface Image to display a remote image showing Mount Etna erupting on July 13th, 2001.
         sector = new Sector(37.46543388598137, 14.60128369746704, 0.45360804083528, 0.75704283995502);
-        String urlString = "http://worldwindserver.net/android/images/etna.jpg";
+        String urlString = "https://worldwind.arc.nasa.gov/android/tutorials/data/etna.jpg";
         SurfaceImage surfaceImageUrl = new SurfaceImage(sector, ImageSource.fromUrl(urlString));
 
         // Add a WorldWindow layer that displays the Surface Image, just before the Atmosphere layer.

--- a/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/SurfaceImageFragment.java
+++ b/worldwind-tutorials/src/main/java/gov/nasa/worldwindx/SurfaceImageFragment.java
@@ -29,7 +29,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
         // Configure a Surface Image to display a remote image showing Mount Etna erupting on July 13th, 2001.
         // TODO sector constructor from North, South, East, West coordinates
         sector = new Sector(37.46543388598137, 14.60128369746704, 0.45360804083528, 0.75704283995502);
-        String urlString = "http://worldwindserver.net/android/images/etna.jpg";
+        String urlString = "https://worldwind.arc.nasa.gov/android/tutorials/data/etna.jpg";
         SurfaceImage surfaceImageUrl = new SurfaceImage(sector, ImageSource.fromUrl(urlString));
 
         // Add a WorldWindow layer that displays the Surface Image, just before the Atmosphere layer.


### PR DESCRIPTION
### Description of the Change

- Moved tutorial data from worldwindserver.net to worldwind.arc.nasa.gov

### Why Should This Be In Core?

- Adjusts references in core code tutorials.

### Benefits

- Hosting on worldwindserver.net is scheduled to be terminated
- Provides HTTPS hosting for tutorial data

### Potential Drawbacks

None.

### Applicable Issues

Closes NASAWorldWind/NASAWorldWind.github.io#112