### PR TITLE
Improve camera to tile distance calculation

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -399,8 +399,14 @@ public class Tile {
 
         long elevationTimestamp = rc.globe.getElevationModel().getTimestamp();
         if (elevationTimestamp != this.heightLimitsTimestamp) {
-            Arrays.fill(this.heightLimits, 0);
+            // initialize the heights for elevation model scan
+            this.heightLimits[0] = Float.MAX_VALUE;
+            this.heightLimits[1] = -Float.MAX_VALUE;
             rc.globe.getElevationModel().getHeightLimits(this.sector, this.heightLimits);
+            // check for valid height limits
+            if (this.heightLimits[0] > this.heightLimits[1]) {
+                Arrays.fill(this.heightLimits, 0f);
+            }
         }
 
         double verticalExaggeration = rc.verticalExaggeration;

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -438,14 +438,15 @@ public class Tile {
         double nearestLon;
         double lonDifference = rc.camera.longitude - this.sector.centroidLongitude();
         if (lonDifference < -180.0) {
-            nearestLon = WWMath.clamp(rc.camera.longitude + 360.0, this.sector.minLongitude(), this.sector.maxLongitude());
+            nearestLon = this.sector.maxLongitude();
         } else if (lonDifference > 180.0) {
-            nearestLon = WWMath.clamp(rc.camera.longitude - 360.0, this.sector.minLongitude(), this.sector.maxLongitude());
+            nearestLon = this.sector.minLongitude();
         } else {
             nearestLon = WWMath.clamp(rc.camera.longitude, this.sector.minLongitude(), this.sector.maxLongitude());
         }
 
-        rc.geographicToCartesian(nearestLat, nearestLon, this.heightLimits[0] * rc.verticalExaggeration, WorldWind.ABSOLUTE, this.nearestPoint);
+        float minHeight = (float) (this.heightLimits[0] * rc.verticalExaggeration);
+        rc.geographicToCartesian(nearestLat, nearestLon, minHeight, WorldWind.ABSOLUTE, this.nearestPoint);
 
         return rc.cameraPoint.distanceTo(this.nearestPoint);
     }

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -10,9 +10,11 @@ import android.util.DisplayMetrics;
 import java.util.Arrays;
 import java.util.Collection;
 
+import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.geom.BoundingBox;
 import gov.nasa.worldwind.geom.Frustum;
 import gov.nasa.worldwind.geom.Sector;
+import gov.nasa.worldwind.geom.Vec3;
 import gov.nasa.worldwind.render.RenderContext;
 
 /**
@@ -70,10 +72,9 @@ public class Tile {
     protected BoundingBox extent;
 
     /**
-     * Cartesian points used for determining distance when the {@link gov.nasa.worldwind.geom.Camera} is not above this
-     * tile.
+     * The nearest point on the tile to the camera. Altitude value is based on the minimum height for the tile.
      */
-    protected float[] samplePoints;
+    protected Vec3 nearestPoint = new Vec3();
 
     protected float[] heightLimits;
 
@@ -431,25 +432,21 @@ public class Tile {
      * @return the distance in meters
      */
     protected double distanceToCamera(RenderContext rc) {
-        if (this.sector.contains(rc.camera.latitude, rc.camera.longitude)) {
-            return rc.camera.altitude;
+        // determine the nearest latitude
+        double nearestLat = WWMath.clamp(rc.camera.latitude, this.sector.minLatitude(), this.sector.maxLatitude());
+        // determine the nearest longitude and account for the antimeridian discontinuity
+        double nearestLon;
+        double lonDifference = rc.camera.longitude - this.sector.centroidLongitude();
+        if (lonDifference < -180.0) {
+            nearestLon = WWMath.clamp(rc.camera.longitude + 360.0, this.sector.minLongitude(), this.sector.maxLongitude());
+        } else if (lonDifference > 180.0) {
+            nearestLon = WWMath.clamp(rc.camera.longitude - 360.0, this.sector.minLongitude(), this.sector.maxLongitude());
+        } else {
+            nearestLon = WWMath.clamp(rc.camera.longitude, this.sector.minLongitude(), this.sector.maxLongitude());
         }
 
-        if (this.samplePoints == null) {
-            this.samplePoints = rc.globe.geographicToCartesianGrid(this.sector, 3, 3, null, 1.0f, null, new float[27], 0, 0);
-        }
+        rc.geographicToCartesian(nearestLat, nearestLon, this.heightLimits[0] * rc.verticalExaggeration, WorldWind.ABSOLUTE, this.nearestPoint);
 
-        double minDistanceSq = Double.MAX_VALUE;
-        for (int i = 0, len = this.samplePoints.length; i < len; i += 3) {
-            double dx = rc.cameraPoint.x - this.samplePoints[i];
-            double dy = rc.cameraPoint.y - this.samplePoints[i + 1];
-            double dz = rc.cameraPoint.z - this.samplePoints[i + 2];
-            double distanceSq = (dx * dx) + (dy * dy) + (dz * dz);
-            if (minDistanceSq > distanceSq) {
-                minDistanceSq = distanceSq;
-            }
-        }
-
-        return Math.sqrt(minDistanceSq);
+        return rc.cameraPoint.distanceTo(this.nearestPoint);
     }
 }


### PR DESCRIPTION
Closes #172 

### Description of the Change

This change uses a continuous and more accurate distance calculation between the camera and tile. The change includes a correction of the minimum height elevation determination to support the higher resolution distance calculation.

### Why Should This Be In Core?

A continuous and more accurate camera to tile distance calculation reduces the level of detail differences between adjacent tiles providing a more seamless scene visualization.

### Potential Drawbacks

The new calculation is more computationally expensive, but testing indicated the frame rate performance was acceptable.

### Applicable Issues

Closes #172
Fixes missioncommand/emp3-android#360