### PR TITLE
Add color properties to text texture cache key and TextAttributes

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
@@ -15,7 +15,6 @@ import gov.nasa.worldwind.PickedObject;
 import gov.nasa.worldwind.PickedObjectList;
 import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.draw.Drawable;
-import gov.nasa.worldwind.draw.DrawableList;
 import gov.nasa.worldwind.draw.DrawableQueue;
 import gov.nasa.worldwind.draw.DrawableTerrain;
 import gov.nasa.worldwind.geom.Camera;
@@ -544,19 +543,25 @@ public class RenderContext {
 
         protected String text;
 
+        protected Color textColor;
+
         protected float textSize;
 
         protected Typeface typeface;
 
         protected boolean enableOutline;
 
+        protected Color outlineColor;
+
         protected float outlineWidth;
 
         public TextCacheKey set(String text, TextAttributes attributes) {
             this.text = text;
+            this.textColor = (attributes != null ? attributes.getTextColor() : null);
             this.textSize = (attributes != null ? attributes.getTextSize() : 0);
             this.typeface = (attributes != null ? attributes.getTypeface() : null);
-            this.enableOutline = (attributes != null ? attributes.isEnableOutline() : false);
+            this.enableOutline = (attributes != null && attributes.isEnableOutline());
+            this.outlineColor = (attributes != null ? attributes.getOutlineColor() : null);
             this.outlineWidth = (attributes != null ? attributes.getOutlineWidth() : 0);
             return this;
         }
@@ -572,18 +577,22 @@ public class RenderContext {
 
             TextCacheKey that = (TextCacheKey) o;
             return ((this.text == null) ? (that.text == null) : this.text.equals(that.text))
+                && this.textColor == that.textColor
                 && this.textSize == that.textSize
                 && ((this.typeface == null) ? (that.typeface == null) : this.typeface.equals(that.typeface))
                 && this.enableOutline == that.enableOutline
+                && this.outlineColor == that.outlineColor
                 && this.outlineWidth == that.outlineWidth;
         }
 
         @Override
         public int hashCode() {
             int result = (this.text != null ? this.text.hashCode() : 0);
+            result = 31 * result + (this.textColor != null ? this.textColor.hashCode() : 0);
             result = 31 * result + (this.textSize != +0.0f ? Float.floatToIntBits(this.textSize) : 0);
             result = 31 * result + (this.typeface != null ? this.typeface.hashCode() : 0);
             result = 31 * result + (this.enableOutline ? 1 : 0);
+            result = 31 * result + (this.outlineColor != null ? this.outlineColor.hashCode() : 0);
             result = 31 * result + (this.outlineWidth != +0.0f ? Float.floatToIntBits(this.outlineWidth) : 0);
             return result;
         }

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
@@ -26,6 +26,8 @@ public class TextAttributes {
 
     protected boolean enableOutline;
 
+    protected Color outlineColor;
+
     protected boolean enableDepthTest;
 
     protected float outlineWidth;
@@ -50,6 +52,7 @@ public class TextAttributes {
         this.textOffset = new Offset(attributes.textOffset);
         this.textSize = attributes.textSize;
         this.typeface = attributes.typeface;
+        this.outlineColor = new Color(attributes.outlineColor);
         this.enableOutline = attributes.enableOutline;
         this.enableDepthTest = attributes.enableDepthTest;
         this.outlineWidth = attributes.outlineWidth;
@@ -66,6 +69,7 @@ public class TextAttributes {
         this.textSize = attributes.textSize;
         this.typeface = attributes.typeface;
         this.enableOutline = attributes.enableOutline;
+        this.outlineColor = new Color(attributes.outlineColor);
         this.enableDepthTest = attributes.enableDepthTest;
         this.outlineWidth = attributes.outlineWidth;
 
@@ -87,6 +91,7 @@ public class TextAttributes {
             && this.textSize == that.textSize
             && ((this.typeface == null) ? (that.typeface == null) : this.typeface.equals(that.typeface))
             && this.enableOutline == that.enableOutline
+            && this.outlineColor.equals(that.outlineColor)
             && this.enableDepthTest == that.enableDepthTest
             && this.outlineWidth == that.outlineWidth;
     }
@@ -98,6 +103,7 @@ public class TextAttributes {
         result = 31 * result + (this.textSize != +0.0f ? Float.floatToIntBits(this.textSize) : 0);
         result = 31 * result + (this.typeface != null ? this.typeface.hashCode() : 0);
         result = 31 * result + (this.enableOutline ? 1 : 0);
+        result = 31 * result + (this.outlineColor != null ? this.outlineColor.hashCode() : 0);
         result = 31 * result + (this.enableDepthTest ? 1 : 0);
         result = 31 * result + (this.outlineWidth != +0.0f ? Float.floatToIntBits(this.outlineWidth) : 0);
         return result;
@@ -156,6 +162,14 @@ public class TextAttributes {
     public TextAttributes setEnableOutline(boolean enable) {
         this.enableOutline = enable;
         return this;
+    }
+
+    public Color getOutlineColor() {
+        return this.outlineColor;
+    }
+
+    public void setOutlineColor(Color outlineColor) {
+        this.outlineColor = outlineColor;
     }
 
     public boolean isEnableDepthTest() {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
@@ -38,7 +38,7 @@ public class TextAttributes {
         this.textSize = 24;
         this.typeface = null;
         this.enableOutline = true;
-        this.outlineColor = new Color(0f, 0f, 0f, 1f);
+        this.outlineColor = new Color(0, 0, 0, 1);
         this.enableDepthTest = true;
         this.outlineWidth = 3;
     }
@@ -70,7 +70,7 @@ public class TextAttributes {
         this.textSize = attributes.textSize;
         this.typeface = attributes.typeface;
         this.enableOutline = attributes.enableOutline;
-        this.outlineColor = new Color(attributes.outlineColor);
+        this.outlineColor.set(attributes.outlineColor);
         this.enableDepthTest = attributes.enableDepthTest;
         this.outlineWidth = attributes.outlineWidth;
 
@@ -169,8 +169,12 @@ public class TextAttributes {
         return this.outlineColor;
     }
 
-    public void setOutlineColor(Color outlineColor) {
-        this.outlineColor = outlineColor;
+    public void setOutlineColor(Color color) {
+        if (color == null) {
+            throw new IllegalArgumentException(
+                Logger.logMessage(Logger.ERROR, "TextAttributes", "setOutlineColor", "missingColor"));
+        }
+        this.outlineColor = color;
     }
 
     public boolean isEnableDepthTest() {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
@@ -38,6 +38,7 @@ public class TextAttributes {
         this.textSize = 24;
         this.typeface = null;
         this.enableOutline = true;
+        this.outlineColor = new Color(0f, 0f, 0f, 1f);
         this.enableDepthTest = true;
         this.outlineWidth = 3;
     }


### PR DESCRIPTION
### Description of the Change

This change adds the text color and text outline color to the RenderContext text texture cache key and to the TextAttributes object.

### Why Should This Be In Core?

Addition of color to the cache key will ensure uniquely colored text will not be lost in the texture cache.

### Applicable Issues

#129 