### PR TITLE
Fix TextAttributes property setting

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
@@ -559,12 +559,15 @@ public class RenderContext {
 
         public TextCacheKey set(String text, TextAttributes attributes) {
             this.text = text;
-            this.textColor = (attributes != null ? attributes.getTextColor() : null);
-            this.textSize = (attributes != null ? attributes.getTextSize() : 0);
-            this.typeface = (attributes != null ? attributes.getTypeface() : null);
-            this.enableOutline = (attributes != null && attributes.isEnableOutline());
-            this.outlineColor = (attributes != null ? attributes.getOutlineColor() : null);
-            this.outlineWidth = (attributes != null ? attributes.getOutlineWidth() : 0);
+            if (attributes != null) {
+                this.textColor = new Color(attributes.getTextColor());
+                this.textSize = attributes.getTextSize();
+                this.typeface = attributes.getTypeface();
+                this.enableOutline = attributes.isEnableOutline();
+                this.outlineColor = new Color(attributes.getOutlineColor());
+                this.outlineWidth = attributes.getOutlineWidth();
+            }
+
             return this;
         }
 
@@ -579,11 +582,11 @@ public class RenderContext {
 
             TextCacheKey that = (TextCacheKey) o;
             return ((this.text == null) ? (that.text == null) : this.text.equals(that.text))
-                && this.textColor == that.textColor
+                && ((this.textColor == null) ? (that.textColor == null) : this.textColor.equals(that.textColor))
                 && this.textSize == that.textSize
                 && ((this.typeface == null) ? (that.typeface == null) : this.typeface.equals(that.typeface))
                 && this.enableOutline == that.enableOutline
-                && this.outlineColor == that.outlineColor
+                && ((this.outlineColor == null) ? (that.outlineColor == null) : this.outlineColor.equals(that.outlineColor))
                 && this.outlineWidth == that.outlineWidth;
         }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
@@ -560,12 +560,19 @@ public class RenderContext {
         public TextCacheKey set(String text, TextAttributes attributes) {
             this.text = text;
             if (attributes != null) {
-                this.textColor = new Color(attributes.getTextColor());
+                this.textColor = (this.textColor != null) ? this.textColor.set(attributes.getTextColor()) : new Color(attributes.getTextColor());
                 this.textSize = attributes.getTextSize();
                 this.typeface = attributes.getTypeface();
                 this.enableOutline = attributes.isEnableOutline();
-                this.outlineColor = new Color(attributes.getOutlineColor());
+                this.outlineColor = (this.outlineColor != null) ? this.outlineColor.set(attributes.getOutlineColor()) : new Color(attributes.getOutlineColor());
                 this.outlineWidth = attributes.getOutlineWidth();
+            } else {
+                this.textColor = null;
+                this.textSize = 0;
+                this.typeface = null;
+                this.enableOutline = false;
+                this.outlineColor = null;
+                this.outlineWidth = 0;
             }
 
             return this;

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
@@ -169,12 +169,14 @@ public class TextAttributes {
         return this.outlineColor;
     }
 
-    public void setOutlineColor(Color color) {
+    public TextAttributes setOutlineColor(Color color) {
         if (color == null) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "TextAttributes", "setOutlineColor", "missingColor"));
         }
-        this.outlineColor = color;
+
+        this.outlineColor.set(color);
+        return this;
     }
 
     public boolean isEnableDepthTest() {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
@@ -104,7 +104,7 @@ public class TextAttributes {
         result = 31 * result + (this.textSize != +0.0f ? Float.floatToIntBits(this.textSize) : 0);
         result = 31 * result + (this.typeface != null ? this.typeface.hashCode() : 0);
         result = 31 * result + (this.enableOutline ? 1 : 0);
-        result = 31 * result + (this.outlineColor != null ? this.outlineColor.hashCode() : 0);
+        result = 31 * result + this.outlineColor.hashCode();
         result = 31 * result + (this.enableDepthTest ? 1 : 0);
         result = 31 * result + (this.outlineWidth != +0.0f ? Float.floatToIntBits(this.outlineWidth) : 0);
         return result;

--- a/worldwind/src/test/java/gov/nasa/worldwind/render/TextCacheKeyTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/render/TextCacheKeyTest.java
@@ -55,6 +55,72 @@ public class TextCacheKeyTest {
     }
 
     @Test
+    public void testNullToNonNullAttributesSet() {
+        String text = "Testing";
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, null);
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, null);
+
+        assertTrue("TextCacheKey null to non-null equals pre", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey null to non-null hashcode pre", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+
+        TextAttributes textAttributes = new TextAttributes();
+        textAttributes.setOutlineWidth(5);
+        textCacheKeyTwo.set(text, textAttributes);
+
+        assertFalse("TextCacheKey null to non-null equals post", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertFalse("TextCacheKey null to non-null hashcode post", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+
+    @Test
+    public void testNullToNullAttributesSet() {
+        String text = "Testing";
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, null);
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, null);
+
+        assertTrue("TextCacheKey null to null equals pre", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey null to null hashcode pre", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+
+        textCacheKeyTwo.set(text, null);
+
+        assertTrue("TextCacheKey null to null equals post", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey null to null hashcode post", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+
+    @Test
+    public void testNonNullToNullAttributesSet() {
+        String text = "Testing";
+        TextAttributes textAttributes = new TextAttributes();
+        textAttributes.setOutlineWidth(5);
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, textAttributes);
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, textAttributes);
+
+        assertTrue("TextCacheKey non-null to null equals pre", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey non-null to null hashcode pre", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+
+        textCacheKeyTwo.set(text, null);
+
+        assertFalse("TextCacheKey non-null to null equals post", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertFalse("TextCacheKey non-null to null hashcode post", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+
+    @Test
+    public void testNonNullToNonNullAttributesSet() {
+        String text = "Testing";
+        TextAttributes textAttributes = new TextAttributes();
+        textAttributes.setOutlineWidth(5);
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, textAttributes);
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, textAttributes);
+
+        assertTrue("TextCacheKey non-null to non-null equals pre", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey non-null to non-null hashcode pre", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+
+        textCacheKeyTwo.set(text, textAttributes);
+
+        assertTrue("TextCacheKey non-null to non-null equals post", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey non-null to non-null hashcode post", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+
+    @Test
     public void testModifiedAttrs() {
         // Common Text Attributes
         TextAttributes attrs = new TextAttributes();

--- a/worldwind/src/test/java/gov/nasa/worldwind/render/TextCacheKeyTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/render/TextCacheKeyTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017 United States Government as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All Rights Reserved.
+ */
+
+package gov.nasa.worldwind.render;
+
+import org.junit.Test;
+
+import gov.nasa.worldwind.shape.TextAttributes;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+public class TextCacheKeyTest {
+
+    @Test
+    public void testIdentical() {
+        // Common Text
+        String text = "Testing";
+
+        // Cache Key 1
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, null);
+        // Cache Key 2
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, null);
+
+        assertTrue("TextCacheKey equals", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey hashcode", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+
+    /**
+     * Test identical cache keys are equal and generate identical hash codes. The {@Typeface} class setting is ignored
+     * as the Android environment is required for non-null values. This has the effect of testing properties set to null
+     * during equivalency testing.
+     */
+    @Test
+    public void testIdenticalWithAttributes() {
+        // Common Text Attributes
+        TextAttributes attrs = new TextAttributes();
+        attrs.setEnableOutline(true);
+        attrs.setOutlineColor(new Color(0.5f, 0.2f, 0.3f, 1));
+        attrs.setOutlineWidth(15);
+        attrs.setTextColor(new Color(1, 1, 0.2f, 1));
+        attrs.setTextSize(90);
+        // Common Text
+        String text = "Testing";
+
+        // Cache Key 1
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, attrs);
+        // Cache Key 2
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, attrs);
+
+        assertTrue("TextCacheKey with attributes equals", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertTrue("TextCacheKey with attributes hashcode", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+
+    @Test
+    public void testModifiedAttrs() {
+        // Common Text Attributes
+        TextAttributes attrs = new TextAttributes();
+        attrs.setEnableOutline(true);
+        attrs.setOutlineColor(new Color(0.5f, 0.2f, 0.3f, 1));
+        attrs.setOutlineWidth(15);
+        attrs.setTextColor(new Color(1, 1, 0.2f, 1));
+        attrs.setTextSize(90);
+        // Common Text
+        String text = "Testing";
+
+        // Cache Key 1
+        RenderContext.TextCacheKey textCacheKeyOne = new RenderContext.TextCacheKey().set(text, attrs);
+        // Modify color property
+        Color outlineColor = attrs.getOutlineColor().set(1, 1, 0.3f, 1);
+        attrs.setOutlineColor(outlineColor);
+        // Cache Key 2
+        RenderContext.TextCacheKey textCacheKeyTwo = new RenderContext.TextCacheKey().set(text, attrs);
+
+        assertFalse("TextCacheKey modified attributes equals", textCacheKeyOne.equals(textCacheKeyTwo));
+        assertFalse("TextCacheKey modified attributes hashcode", textCacheKeyOne.hashCode() == textCacheKeyTwo.hashCode());
+    }
+}


### PR DESCRIPTION
Closes #182 

### Description of the Change

This pull request corrects the setting of outline color properties and equivalency evaluation of the TextCacheKey object. A small set of test cases is included to verify the "happy-path" operation.

### Applicable Issues

#182 