### PR TITLE
Change Sector intersection conditions for surface shape drawing

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawableSurfaceShape.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/draw/DrawableSurfaceShape.java
@@ -135,7 +135,7 @@ public class DrawableSurfaceShape implements Drawable {
                 // Get the shape.
                 DrawableSurfaceShape shape = (DrawableSurfaceShape) scratchList.get(idx);
 
-                if (!shape.sector.intersects(terrainSector)) {
+                if (!shape.sector.intersectsOrNextTo(terrainSector)) {
                     continue;
                 }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/geom/Sector.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/geom/Sector.java
@@ -353,6 +353,31 @@ public class Sector {
     }
 
     /**
+     * Indicates whether this sector is next to or intersects a specified sector. Two sectors intersect if meeting the
+     * {@link Sector#intersects(Sector)} methods criteria and if the boundary or corner is shared with the specified
+     * sector. This is a temporary implementation and will be deprecated in future releases.
+     *
+     * @param sector the sector to test intersection with
+     *
+     * @return true if the specified sector intersects or is next to this sector, false otherwise
+     *
+     * @throws IllegalArgumentException If the sector is null
+     */
+    public boolean intersectsOrNextTo(Sector sector) {
+        if (sector == null) {
+            throw new IllegalArgumentException(
+                Logger.logMessage(Logger.ERROR, "Sector", "intersects", "missingSector"));
+        }
+
+        // Assumes normalized angles: [-90, +90], [-180, +180]
+        // Note: comparisons with NaN are always false
+        return this.minLatitude <= sector.maxLatitude
+            && this.maxLatitude >= sector.minLatitude
+            && this.minLongitude <= sector.maxLongitude
+            && this.maxLongitude >= sector.minLongitude;
+    }
+
+    /**
      * Computes the intersection of this sector and a specified sector, storing the result in this sector and returning
      * whether or not the sectors intersect. Two sectors intersect when both the latitude boundaries and the longitude
      * boundaries overlap by a non-zero amount. An empty sector never intersects another sector. When there is no

--- a/worldwind/src/main/java/gov/nasa/worldwind/geom/Sector.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/geom/Sector.java
@@ -353,9 +353,9 @@ public class Sector {
     }
 
     /**
-     * Indicates whether this sector is next to or intersects a specified sector. Two sectors intersect if meeting the
-     * {@link Sector#intersects(Sector)} methods criteria and if the boundary or corner is shared with the specified
-     * sector. This is a temporary implementation and will be deprecated in future releases.
+     * Indicates if this sector is next to, or intersects, a specified sector. Two sectors intersect when the conditions
+     * of the {@link Sector#intersects(Sector)} methods have been met, and if the boundary or corner is shared with the
+     * specified sector. This is a temporary implementation and will be deprecated in future releases.
      *
      * @param sector the sector to test intersection with
      *


### PR DESCRIPTION
Closes #185 

### Description of the Change

A temporary method, `intersectsOrNextTo` has been added to Sector which operates similarly to the current `intersects` method, but, unlike `intersects` returns `true` if the specified Sector shares a boundary or corner with the Sector. The method is added as a temporary solution for #185. Using `intersectsOrNextTo` will allow surface shapes to be drawn on tile boundaries.

### Applicable Issues

Fixes #185 