### PR TITLE
Reuse Ellipse element buffers to reduce memory use

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
@@ -411,7 +411,7 @@ public class Ellipse extends AbstractShape {
         ElementBufferAttributes elementBufferAttributes = ELEMENT_BUFFER_ATTRIBUTES.get(this.intervals);
         if (elementBufferAttributes == null ||
             (drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes)) == null) {
-            elementBufferAttributes = assembleAndCacheElements(rc, this.intervals);
+            elementBufferAttributes = aseembleElementsToCache(rc, this.intervals);
             drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
         }
 
@@ -526,7 +526,7 @@ public class Ellipse extends AbstractShape {
         this.boundingBox.setToUnitBox(); // Surface/geographic shape bounding box is unused
     }
 
-    protected static ElementBufferAttributes assembleAndCacheElements(RenderContext rc, int intervals) {
+    protected static ElementBufferAttributes aseembleElementsToCache(RenderContext rc, int intervals) {
         // Create temporary storage for elements
         ShortArray interiorElements = new ShortArray();
         ShortArray outlineElements = new ShortArray();

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
@@ -565,10 +565,10 @@ public class Ellipse extends AbstractShape {
         }
 
         // Generate an attribute bundle for this element buffer
-        ElementBufferAttributes elementBufferCacheKey = new ElementBufferAttributes();
-        elementBufferCacheKey.interiorElementCount = interiorElements.size();
-        elementBufferCacheKey.outlineElementCount = outlineElements.size();
-        elementBufferCacheKey.outlineOffset = interiorElements.size() * 2;
+        ElementBufferAttributes elementBufferAttributes = new ElementBufferAttributes();
+        elementBufferAttributes.interiorElementCount = interiorElements.size();
+        elementBufferAttributes.outlineElementCount = outlineElements.size();
+        elementBufferAttributes.outlineOffset = interiorElements.size() * 2;
 
         // Generate a buffer for the element
         int size = (interiorElements.size() * 2) + (outlineElements.size() * 2);
@@ -578,10 +578,10 @@ public class Ellipse extends AbstractShape {
         BufferObject elementBuffer = new BufferObject(GLES20.GL_ELEMENT_ARRAY_BUFFER, size, buffer.rewind());
 
         // Cache the buffer object and attributes in the render resource cache and attribute map respectively
-        rc.putBufferObject(elementBufferCacheKey, elementBuffer);
-        ELEMENT_BUFFER_ATTRIBUTES.put(intervals, elementBufferCacheKey);
+        rc.putBufferObject(elementBufferAttributes, elementBuffer);
+        ELEMENT_BUFFER_ATTRIBUTES.put(intervals, elementBufferAttributes);
 
-        return elementBufferCacheKey;
+        return elementBufferAttributes;
     }
 
     protected void addVertex(RenderContext rc, double latitude, double longitude, double altitude) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
@@ -408,13 +408,25 @@ public class Ellipse extends AbstractShape {
         }
 
 
-        // Assemble the drawable's OpenGL element buffer object.
+        // Check for an existing element buffer
         ElementBufferData elementBufferData = ELEMENT_BUFFERS.get(this.intervals);
         if (elementBufferData == null) {
             elementBufferData = assembleElements(this.intervals);
+            elementBufferData.resourceKey = nextCacheKey();
+            rc.putBufferObject(elementBufferData.resourceKey, elementBufferData.elementBuffer);
             ELEMENT_BUFFERS.put(this.intervals, elementBufferData);
+            elementBufferData.elementBuffer = null;
         }
-        drawState.elementBuffer = elementBufferData.elementBuffer;
+
+        // Check for the buffer in the render resource cache
+        drawState.elementBuffer = rc.getBufferObject(elementBufferData.resourceKey);
+        if (drawState.elementBuffer == null) {
+            elementBufferData = assembleElements(this.intervals);
+            elementBufferData.resourceKey = nextCacheKey();
+            rc.putBufferObject(elementBufferData.resourceKey, elementBufferData.elementBuffer);
+            ELEMENT_BUFFERS.put(this.intervals, elementBufferData);
+            elementBufferData.elementBuffer = null;
+        }
 
         this.drawInterior(rc, drawState, elementBufferData);
         this.drawOutline(rc, drawState, elementBufferData);
@@ -645,5 +657,7 @@ public class Ellipse extends AbstractShape {
         protected int outlineOffset;
 
         protected BufferObject elementBuffer;
+
+        protected Object resourceKey;
     }
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
@@ -409,8 +409,8 @@ public class Ellipse extends AbstractShape {
 
         // Get the attributes of the element buffer
         ElementBufferAttributes elementBufferAttributes = ELEMENT_BUFFER_ATTRIBUTES.get(this.intervals);
-        if (elementBufferAttributes == null ||
-            (drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes)) == null) {
+        drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
+        if (drawState.elementBuffer == null) {
             elementBufferAttributes = aseembleElementsToCache(rc, this.intervals);
             drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
         }

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
@@ -409,14 +409,8 @@ public class Ellipse extends AbstractShape {
 
         // Get the attributes of the element buffer
         ElementBufferAttributes elementBufferAttributes = ELEMENT_BUFFER_ATTRIBUTES.get(this.intervals);
-        if (elementBufferAttributes == null) {
-            elementBufferAttributes = assembleAndCacheElements(rc, this.intervals);
-        }
-
-        // Check for an existing element buffer
-        drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
-        if (drawState.elementBuffer == null) {
-            // The attribute key must be stale, update the attributes and buffer
+        if (elementBufferAttributes == null ||
+            (drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes)) == null) {
             elementBufferAttributes = assembleAndCacheElements(rc, this.intervals);
             drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
         }
@@ -434,7 +428,7 @@ public class Ellipse extends AbstractShape {
         rc.offerSurfaceDrawable(drawable, 0 /*zOrder*/);
     }
 
-    protected void drawInterior(RenderContext rc, DrawShapeState drawState, ElementBufferAttributes elementBufferAttributes) {
+    protected void drawInterior(RenderContext rc, DrawShapeState drawState, ElementBufferAttributes elementBufferAttrs) {
         if (!this.activeAttributes.drawInterior) {
             return;
         }
@@ -444,11 +438,11 @@ public class Ellipse extends AbstractShape {
         // Configure the drawable to display the shape's interior.
         drawState.color(rc.pickMode ? this.pickColor : this.activeAttributes.interiorColor);
         drawState.texCoordAttrib(2 /*size*/, 12 /*offset in bytes*/);
-        drawState.drawElements(GLES20.GL_TRIANGLE_STRIP, elementBufferAttributes.interiorElementCount,
+        drawState.drawElements(GLES20.GL_TRIANGLE_STRIP, elementBufferAttrs.interiorElementCount,
             GLES20.GL_UNSIGNED_SHORT, 0 /*offset*/);
     }
 
-    protected void drawOutline(RenderContext rc, DrawShapeState drawState, ElementBufferAttributes elementBufferAttributes) {
+    protected void drawOutline(RenderContext rc, DrawShapeState drawState, ElementBufferAttributes elementBufferAttrs) {
         if (!this.activeAttributes.drawOutline) {
             return;
         }
@@ -459,8 +453,8 @@ public class Ellipse extends AbstractShape {
         drawState.color(rc.pickMode ? this.pickColor : this.activeAttributes.outlineColor);
         drawState.lineWidth(this.activeAttributes.outlineWidth);
         drawState.texCoordAttrib(1 /*size*/, 20 /*offset in bytes*/);
-        drawState.drawElements(GLES20.GL_LINE_LOOP, elementBufferAttributes.outlineElementCount,
-            GLES20.GL_UNSIGNED_SHORT, elementBufferAttributes.outlineOffset /*offset*/);
+        drawState.drawElements(GLES20.GL_LINE_LOOP, elementBufferAttrs.outlineElementCount,
+            GLES20.GL_UNSIGNED_SHORT, elementBufferAttrs.outlineOffset /*offset*/);
     }
 
     protected boolean mustAssembleGeometry(RenderContext rc) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Ellipse.java
@@ -412,7 +412,7 @@ public class Ellipse extends AbstractShape {
         ElementBufferAttributes elementBufferAttributes = ELEMENT_BUFFER_ATTRIBUTES.get(this.intervals);
         drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
         if (drawState.elementBuffer == null) {
-            elementBufferAttributes = aseembleElementsToCache(rc, this.intervals);
+            elementBufferAttributes = assembleElementsToCache(rc, this.intervals);
             drawState.elementBuffer = rc.getBufferObject(elementBufferAttributes);
         }
 
@@ -527,7 +527,7 @@ public class Ellipse extends AbstractShape {
         this.boundingBox.setToUnitBox(); // Surface/geographic shape bounding box is unused
     }
 
-    protected static ElementBufferAttributes aseembleElementsToCache(RenderContext rc, int intervals) {
+    protected static ElementBufferAttributes assembleElementsToCache(RenderContext rc, int intervals) {
         // Create temporary storage for elements
         ShortArray interiorElements = new ShortArray();
         ShortArray outlineElements = new ShortArray();


### PR DESCRIPTION
### Description of the Change

The element buffer for Ellipse is unique only to the number of intervals in the shape. Ellipses sharing a similar interval count but different sizes and positions can utilize the same element buffer. Reusing the element buffer reduces memory and buffer generation overhead.

This pull request implements element buffer reuse for Ellipses. The element buffer is still maintained in the `RenderContext` `renderResourceCache` but reused by Ellipses with similar interval counts.

### Applicable Issues

Closes #207 