### PR TITLE
Fix render resources cache size determination.

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/WorldWindow.java
@@ -178,7 +178,7 @@ public class WorldWindow extends GLSurfaceView implements Choreographer.FrameCal
         this.worldWindowController.setWorldWindow(this);
 
         // Initialize the WorldWindow's render resource cache.
-        int cacheCapacity = RenderResourceCache.recommendedCapacity(this.getContext());
+        int cacheCapacity = RenderResourceCache.recommendedCapacity();
         this.renderResourceCache = new RenderResourceCache(cacheCapacity);
 
         // Set up to render on demand to an OpenGL ES 2.x context

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderResourceCache.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderResourceCache.java
@@ -5,8 +5,6 @@
 
 package gov.nasa.worldwind.render;
 
-import android.app.ActivityManager;
-import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.opengl.GLES20;
@@ -67,25 +65,8 @@ public class RenderResourceCache extends LruMemoryCache<Object, RenderResource>
             this.getCapacity() / 1024.0, this.imageRetrieverCache.getCapacity() / 1024.0));
     }
 
-    public static int recommendedCapacity(Context context) {
-        ActivityManager am = (context != null) ? (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE) : null;
-        if (am != null) {
-            ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
-            am.getMemoryInfo(mi);
-            if (mi.totalMem >= 1024 * 1024 * 2048L) { // use 384 MB on machines with 2048 MB or more
-                return 1024 * 1024 * 384;
-            } else if (mi.totalMem >= 1024 * 1024 * 1536) { // use 256 MB on machines with 1536 MB or more
-                return 1024 * 1024 * 256;
-            } else if (mi.totalMem >= 1024 * 1024 * 1024) { // use 192 MB on machines with 1024 MB or more
-                return 1024 * 1024 * 192;
-            } else if (mi.totalMem >= 1024 * 1024 * 512) { // use 96 MB on machines with 512 MB or more
-                return 1024 * 1024 * 96;
-            } else { // use 64 MB on machines with less than 512 MB
-                return 1024 * 1024 * 64;
-            }
-        } else { // use 64 MB by default
-            return 1024 * 1024 * 64;
-        }
+    public static int recommendedCapacity() {
+        return (int) (Runtime.getRuntime().maxMemory() * 0.75); // Use maximum 75% of available application heap
     }
 
     public Resources getResources() {


### PR DESCRIPTION
### Description of the Change
Fixed recommended capacity of render resource cache calculation.

Currently render resource cache capacity is calculated using some magic numbers based on total device memory capacity. Using this approach any device with 2GB RAM use 384Mb of resource cache. 
But total memory and available application heap are not the same. For example, Samsung Note 9 has 6GB of device RAM, but only 256Mb heap available for each application in standard mode and 512MB in "largeHeap" mode. As you can see 384Mb cache size is much bigger than 256Mb available heap, which cause application crash during intensive use, when cache reaches its capacity limit.
https://stackoverflow.com/questions/2630158/detect-application-heap-size-in-android

### Why Should This Be In Core?
This issue is the reason of application crash on many devices with large amount of memory.

### Benefits
Fix application crash.

### Potential Drawbacks
Incorrect multiplication coefficient may be used, which cause ineffective memory usage on some devices.
I have selected coefficient magic number = 0.75, but in some cases if application itself use very few amount of memory it may ineffectively use available heap, in other hand if application is very heavy and use more then 25% of heap, it may cause memory overflow and crash.