### PR TITLE
Fix GeoPackage support implementation.

### DIFF
--- a/worldwind/src/main/java/gov/nasa/worldwind/globe/BasicTessellator.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/globe/BasicTessellator.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import gov.nasa.worldwind.draw.BasicDrawableTerrain;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Range;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.geom.Vec3;
@@ -32,7 +33,7 @@ import gov.nasa.worldwind.util.TileFactory;
 public class BasicTessellator implements Tessellator, TileFactory {
 
     // ~0.6 meter resolution
-    protected LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), 90, 20, 32, 32);
+    protected LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), 90, 20, 32, 32);
 
     protected double detailControl = 80;
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/globe/BasicTessellator.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/globe/BasicTessellator.java
@@ -33,7 +33,7 @@ import gov.nasa.worldwind.util.TileFactory;
 public class BasicTessellator implements Tessellator, TileFactory {
 
     // ~0.6 meter resolution
-    protected LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), 90, 20, 32, 32);
+    protected LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), new Location(90, 90), 20, 32, 32);
 
     protected double detailControl = 80;
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/BlueMarbleLandsatLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/BlueMarbleLandsatLayer.java
@@ -85,7 +85,7 @@ public class BlueMarbleLandsatLayer extends RenderableLayer implements TileFacto
 
     @Override
     public Tile createTile(Sector sector, Level level, int row, int column) {
-        double radiansPerPixel = Math.toRadians(level.tileDelta) / level.tileHeight;
+        double radiansPerPixel = Math.toRadians(level.tileDelta.latitude) / level.tileHeight;
         double metersPerPixel = radiansPerPixel * WorldWind.WGS84_SEMI_MAJOR_AXIS;
 
         if (metersPerPixel < 2.0e3) { // switch to Landsat at 2km resolution

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.ogc.WmsLayerConfig;
 import gov.nasa.worldwind.ogc.WmsTileFactory;
@@ -670,7 +671,7 @@ public class LayerFactory {
         }
         int imageSize = tileMatrixSet.getTileMatrices().get(0).getTileHeight();
 
-        return new LevelSet(boundingBox, 90.0, compatibleTileMatrixSet.tileMatrices.size(), imageSize, imageSize);
+        return new LevelSet(boundingBox, new Location(-90, -180), 90, compatibleTileMatrixSet.tileMatrices.size(), imageSize, imageSize);
     }
 
     protected String buildWmtsKvpTemplate(String kvpServiceAddress, String layer, String format, String styleIdentifier, String tileMatrixSet) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
@@ -8,6 +8,7 @@ package gov.nasa.worldwind.layer;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.SparseArray;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
@@ -30,6 +31,7 @@ import gov.nasa.worldwind.ogc.gpkg.GeoPackage;
 import gov.nasa.worldwind.ogc.gpkg.GpkgContent;
 import gov.nasa.worldwind.ogc.gpkg.GpkgSpatialReferenceSystem;
 import gov.nasa.worldwind.ogc.gpkg.GpkgTileFactory;
+import gov.nasa.worldwind.ogc.gpkg.GpkgTileMatrix;
 import gov.nasa.worldwind.ogc.gpkg.GpkgTileMatrixSet;
 import gov.nasa.worldwind.ogc.gpkg.GpkgTileUserMetrics;
 import gov.nasa.worldwind.ogc.wms.WmsCapabilities;
@@ -259,6 +261,13 @@ public class LayerFactory {
                 continue;
             }
 
+            SparseArray<GpkgTileMatrix> tileMatrix = geoPackage.getTileMatrix(content.getTableName());
+            if (tileMatrix == null || tileMatrix.size() == 0) {
+                Logger.logMessage(Logger.WARN, "LayerFactory", "createFromGeoPackageAsync",
+                        "Unsupported GeoPackage tile matrix");
+                continue;
+            }
+
             GpkgTileUserMetrics tileMetrics = geoPackage.getTileUserMetrics(content.getTableName());
             if (tileMetrics == null) {
                 Logger.logMessage(Logger.WARN, "LayerFactory", "createFromGeoPackageAsync",
@@ -267,14 +276,15 @@ public class LayerFactory {
             }
 
             LevelSetConfig config = new LevelSetConfig();
-            config.sector.set(content.getMinY(), content.getMinX(),
-                content.getMaxY() - content.getMinY(), content.getMaxX() - content.getMinX());
-            config.firstLevelDelta = 180;
-            config.numLevels = tileMetrics.getMaxZoomLevel() + 1; // zero when there are no zoom levels, (0 = -1 + 1)
-            config.tileWidth = 256;
-            config.tileHeight = 256;
+            config.sector.set(tileMatrixSet.getMinY(), tileMatrixSet.getMinX(),
+                    tileMatrixSet.getMaxY() - tileMatrixSet.getMinY(),
+                    tileMatrixSet.getMaxX() - tileMatrixSet.getMinX());
+            config.tileOrigin.set(tileMatrixSet.getMinY(), tileMatrixSet.getMinX());
+            config.firstLevelDelta = (tileMatrixSet.getMaxY() - tileMatrixSet.getMinY()) / tileMatrix.valueAt(0).getMatrixHeight();
+            config.numLevels = tileMatrix.size();
 
             TiledSurfaceImage surfaceImage = new TiledSurfaceImage();
+            surfaceImage.setDisplayName(content.getIdentifier());
             surfaceImage.setLevelSet(new LevelSet(config));
             surfaceImage.setTileFactory(new GpkgTileFactory(content));
             gpkgRenderables.addRenderable(surfaceImage);

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
@@ -280,7 +280,10 @@ public class LayerFactory {
                     tileMatrixSet.getMaxY() - tileMatrixSet.getMinY(),
                     tileMatrixSet.getMaxX() - tileMatrixSet.getMinX());
             config.tileOrigin.set(tileMatrixSet.getMinY(), tileMatrixSet.getMinX());
-            config.firstLevelDelta = (tileMatrixSet.getMaxY() - tileMatrixSet.getMinY()) / tileMatrix.valueAt(0).getMatrixHeight();
+            config.firstLevelDelta.set(
+                (tileMatrixSet.getMaxY() - tileMatrixSet.getMinY()) / tileMatrix.valueAt(0).getMatrixHeight(),
+                (tileMatrixSet.getMaxX() - tileMatrixSet.getMinX()) / tileMatrix.valueAt(0).getMatrixWidth()
+            );
             config.numLevels = tileMatrix.keyAt(tileMatrix.size() - 1) - tileMatrix.keyAt(0) + 1;
 
             TiledSurfaceImage surfaceImage = new TiledSurfaceImage();
@@ -681,7 +684,7 @@ public class LayerFactory {
         }
         int imageSize = tileMatrixSet.getTileMatrices().get(0).getTileHeight();
 
-        return new LevelSet(boundingBox, new Location(-90, -180), 90, compatibleTileMatrixSet.tileMatrices.size(), imageSize, imageSize);
+        return new LevelSet(boundingBox, new Location(-90, -180), new Location(90, 90), compatibleTileMatrixSet.tileMatrices.size(), imageSize, imageSize);
     }
 
     protected String buildWmtsKvpTemplate(String kvpServiceAddress, String layer, String format, String styleIdentifier, String tileMatrixSet) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/LayerFactory.java
@@ -281,7 +281,7 @@ public class LayerFactory {
                     tileMatrixSet.getMaxX() - tileMatrixSet.getMinX());
             config.tileOrigin.set(tileMatrixSet.getMinY(), tileMatrixSet.getMinX());
             config.firstLevelDelta = (tileMatrixSet.getMaxY() - tileMatrixSet.getMinY()) / tileMatrix.valueAt(0).getMatrixHeight();
-            config.numLevels = tileMatrix.size();
+            config.numLevels = tileMatrix.keyAt(tileMatrix.size() - 1) - tileMatrix.keyAt(0) + 1;
 
             TiledSurfaceImage surfaceImage = new TiledSurfaceImage();
             surfaceImage.setDisplayName(content.getIdentifier());

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
@@ -1,0 +1,142 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import android.graphics.Bitmap;
+
+import java.util.Collection;
+
+import gov.nasa.worldwind.render.ImageSource;
+import gov.nasa.worldwind.render.ImageTile;
+import gov.nasa.worldwind.util.Level;
+import gov.nasa.worldwind.util.LevelSet;
+import gov.nasa.worldwind.util.Logger;
+import gov.nasa.worldwind.util.Tile;
+import gov.nasa.worldwind.util.TileFactory;
+
+class MercatorImageTile extends ImageTile implements ImageSource.Transformer {
+
+    /**
+     * Constructs a tile with a specified sector, level, row and column.
+     *
+     * @param sector the sector spanned by the tile
+     * @param level  the tile's level in a {@link LevelSet}
+     * @param row    the tile's row within the specified level
+     * @param column the tile's column within the specified level
+     */
+    MercatorImageTile(MercatorSector sector, Level level, int row, int column) {
+        super(sector, level, row, column);
+    }
+
+    /**
+     * Creates all Mercator tiles for a specified level within a {@link LevelSet}.
+     *
+     * @param level       the level to create the tiles for
+     * @param tileFactory the tile factory to use for creating tiles.
+     * @param result      an pre-allocated Collection in which to store the results
+     */
+    static void assembleMercatorTilesForLevel(Level level, TileFactory tileFactory, Collection<Tile> result) {
+        if (level == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingLevel"));
+        }
+
+        if (tileFactory == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingTileFactory"));
+        }
+
+        if (result == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingResult"));
+        }
+
+        // NOTE LevelSet.sector is final Sector attribute and thus can not be cast to MercatorSector!
+        MercatorSector sector = MercatorSector.fromSector(level.parent.sector);
+        double dLat = level.tileDelta / 2;
+        double dLon = level.tileDelta;
+
+        int firstRow = Tile.computeRow(dLat, sector.minLatitude());
+        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude());
+        int firstCol = Tile.computeColumn(dLon, sector.minLongitude());
+        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude());
+
+        double deltaLat = dLat / 90;
+        double d1 = sector.minLatPercent() + deltaLat * firstRow;
+        for (int row = firstRow; row <= lastRow; row++) {
+            double d2 = d1 + deltaLat;
+            double t1 = sector.minLongitude() + (firstCol * dLon);
+            for (int col = firstCol; col <= lastCol; col++) {
+                double t2;
+                t2 = t1 + dLon;
+                result.add(tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t1, t2), level, row, col));
+                t1 = t2;
+            }
+            d1 = d2;
+        }
+    }
+
+    /**
+     * Returns the four children formed by subdividing this tile. This tile's sector is subdivided into four quadrants
+     * as follows: Southwest; Southeast; Northwest; Northeast. A new tile is then constructed for each quadrant and
+     * configured with the next level within this tile's LevelSet and its corresponding row and column within that
+     * level. This returns null if this tile's level is the last level within its {@link LevelSet}.
+     *
+     * @param tileFactory the tile factory to use to create the children
+     *
+     * @return an array containing the four child tiles, or null if this tile's level is the last level
+     */
+    @Override
+    public Tile[] subdivide(TileFactory tileFactory) {
+        if (tileFactory == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "subdivide", "missingTileFactory"));
+        }
+
+        Level childLevel = this.level.nextLevel();
+        if (childLevel == null) {
+            return null;
+        }
+
+        MercatorSector sector = (MercatorSector) this.sector;
+
+        double d0 = sector.minLatPercent();
+        double d2 = sector.maxLatPercent();
+        double d1 = d0 + (d2 - d0) / 2.0;
+
+        double t0 = sector.minLongitude();
+        double t2 = sector.maxLongitude();
+        double t1 = 0.5 * (t0 + t2);
+
+        int northRow = 2 * this.row;
+        int southRow = northRow + 1;
+        int westCol = 2 * this.column;
+        int eastCol = westCol + 1;
+
+        Tile[] children = new Tile[4];
+        children[0] = tileFactory.createTile(MercatorSector.fromDegrees(d0, d1, t0, t1), childLevel, northRow, westCol);
+        children[1] = tileFactory.createTile(MercatorSector.fromDegrees(d0, d1, t1, t2), childLevel, northRow, eastCol);
+        children[2] = tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t0, t1), childLevel, southRow, westCol);
+        children[3] = tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t1, t2), childLevel, southRow, eastCol);
+
+        return children;
+    }
+
+    @Override
+    public Bitmap transform(Bitmap bitmap) {
+        // Re-project mercator tile to equirectangular
+        Bitmap trans = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), bitmap.getConfig());
+        double miny = ((MercatorSector) sector).minLatPercent();
+        double maxy = ((MercatorSector) sector).maxLatPercent();
+        for (int y = 0; y < bitmap.getHeight(); y++) {
+            double sy = 1.0 - y / (double) (bitmap.getHeight() - 1);
+            double lat = sy * (sector.maxLatitude() - sector.minLatitude()) + sector.minLatitude();
+            double dy = 1.0 - (MercatorSector.gudermannianInverse(lat) - miny) / (maxy - miny);
+            dy = Math.max(0.0, Math.min(1.0, dy));
+            int iy = (int) (dy * (bitmap.getHeight() - 1));
+            for (int x = 0; x < bitmap.getWidth(); x++) {
+                trans.setPixel(x, y, bitmap.getPixel(x, iy));
+            }
+        }
+        return trans;
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
@@ -1,0 +1,144 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import android.graphics.Bitmap;
+
+import java.util.Collection;
+
+import gov.nasa.worldwind.render.ImageTile;
+import gov.nasa.worldwind.util.DownloadPostprocessor;
+import gov.nasa.worldwind.util.Level;
+import gov.nasa.worldwind.util.LevelSet;
+import gov.nasa.worldwind.util.Logger;
+import gov.nasa.worldwind.util.Tile;
+import gov.nasa.worldwind.util.TileFactory;
+
+class MercatorImageTile extends ImageTile implements DownloadPostprocessor<Bitmap> {
+
+    /**
+     * Constructs a tile with a specified sector, level, row and column.
+     *
+     * @param sector the sector spanned by the tile
+     * @param level  the tile's level in a {@link LevelSet}
+     * @param row    the tile's row within the specified level
+     * @param column the tile's column within the specified level
+     */
+    MercatorImageTile(MercatorSector sector, Level level, int row, int column) {
+        super(sector, level, row, column);
+    }
+
+    /**
+     * Creates all Mercator tiles for a specified level within a {@link LevelSet}.
+     *
+     * @param level       the level to create the tiles for
+     * @param tileFactory the tile factory to use for creating tiles.
+     * @param result      an pre-allocated Collection in which to store the results
+     */
+    static void assembleMercatorTilesForLevel(Level level, TileFactory tileFactory, Collection<Tile> result) {
+        if (level == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingLevel"));
+        }
+
+        if (tileFactory == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingTileFactory"));
+        }
+
+        if (result == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "assembleTilesForLevel", "missingResult"));
+        }
+
+        // NOTE LevelSet.sector is final Sector attribute and thus can not be cast to MercatorSector!
+        MercatorSector sector = MercatorSector.fromSector(level.parent.sector);
+        double dLat = level.tileDelta / 2;
+        double dLon = level.tileDelta;
+
+        int firstRow = Tile.computeRow(dLat, sector.minLatitude());
+        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude());
+        int firstCol = Tile.computeColumn(dLon, sector.minLongitude());
+        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude());
+
+        double deltaLat = dLat / 90;
+        double d1 = sector.minLatPercent() + deltaLat * firstRow;
+        for (int row = firstRow; row <= lastRow; row++) {
+            double d2 = d1 + deltaLat;
+            double t1 = sector.minLongitude() + (firstCol * dLon);
+            for (int col = firstCol; col <= lastCol; col++) {
+                double t2;
+                t2 = t1 + dLon;
+                result.add(tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t1, t2), level, row, col));
+                t1 = t2;
+            }
+            d1 = d2;
+        }
+    }
+
+    /**
+     * Returns the four children formed by subdividing this tile. This tile's sector is subdivided into four quadrants
+     * as follows: Southwest; Southeast; Northwest; Northeast. A new tile is then constructed for each quadrant and
+     * configured with the next level within this tile's LevelSet and its corresponding row and column within that
+     * level. This returns null if this tile's level is the last level within its {@link LevelSet}.
+     *
+     * @param tileFactory the tile factory to use to create the children
+     *
+     * @return an array containing the four child tiles, or null if this tile's level is the last level
+     */
+    @Override
+    public Tile[] subdivide(TileFactory tileFactory) {
+        if (tileFactory == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "Tile", "subdivide", "missingTileFactory"));
+        }
+
+        Level childLevel = this.level.nextLevel();
+        if (childLevel == null) {
+            return null;
+        }
+
+        MercatorSector sector = (MercatorSector) this.sector;
+
+        double d0 = sector.minLatPercent();
+        double d2 = sector.maxLatPercent();
+        double d1 = d0 + (d2 - d0) / 2.0;
+
+        double t0 = sector.minLongitude();
+        double t2 = sector.maxLongitude();
+        double t1 = 0.5 * (t0 + t2);
+
+        int northRow = 2 * this.row;
+        int southRow = northRow + 1;
+        int westCol = 2 * this.column;
+        int eastCol = westCol + 1;
+
+        Tile[] children = new Tile[4];
+        children[0] = tileFactory.createTile(MercatorSector.fromDegrees(d0, d1, t0, t1), childLevel, northRow, westCol);
+        children[1] = tileFactory.createTile(MercatorSector.fromDegrees(d0, d1, t1, t2), childLevel, northRow, eastCol);
+        children[2] = tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t0, t1), childLevel, southRow, westCol);
+        children[3] = tileFactory.createTile(MercatorSector.fromDegrees(d1, d2, t1, t2), childLevel, southRow, eastCol);
+
+        return children;
+    }
+
+    @Override
+    public Bitmap process(Bitmap resource) {
+        // Re-project mercator tile to equirectangular
+        int[] pixels = new int[resource.getWidth() * resource.getHeight()];
+        int[] result = new int[resource.getWidth() * resource.getHeight()];
+        resource.getPixels(pixels, 0, resource.getWidth(), 0, 0, resource.getWidth(), resource.getHeight());
+        double miny = ((MercatorSector) sector).minLatPercent();
+        double maxy = ((MercatorSector) sector).maxLatPercent();
+        for (int y = 0; y < resource.getHeight(); y++) {
+            double sy = 1.0 - y / (double) (resource.getHeight() - 1);
+            double lat = sy * (sector.maxLatitude() - sector.minLatitude()) + sector.minLatitude();
+            double dy = 1.0 - (MercatorSector.gudermannianInverse(lat) - miny) / (maxy - miny);
+            dy = Math.max(0.0, Math.min(1.0, dy));
+            int iy = (int) (dy * (resource.getHeight() - 1));
+            for (int x = 0; x < resource.getWidth(); x++) {
+                result[x + y * resource.getWidth()] = pixels[x + iy * resource.getWidth()];
+            }
+        }
+        return Bitmap.createBitmap(result, resource.getWidth(), resource.getHeight(), resource.getConfig());
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorImageTile.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 
 import java.util.Collection;
 
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.render.ImageSource;
 import gov.nasa.worldwind.render.ImageTile;
 import gov.nasa.worldwind.util.Level;
@@ -51,19 +52,20 @@ class MercatorImageTile extends ImageTile implements ImageSource.Transformer {
 
         // NOTE LevelSet.sector is final Sector attribute and thus can not be cast to MercatorSector!
         MercatorSector sector = MercatorSector.fromSector(level.parent.sector);
+        Location tileOrigin = level.parent.tileOrigin;
         double dLat = level.tileDelta / 2;
         double dLon = level.tileDelta;
 
-        int firstRow = Tile.computeRow(dLat, sector.minLatitude());
-        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude());
-        int firstCol = Tile.computeColumn(dLon, sector.minLongitude());
-        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude());
+        int firstRow = Tile.computeRow(dLat, sector.minLatitude(), tileOrigin.latitude);
+        int lastRow = Tile.computeLastRow(dLat, sector.maxLatitude(), tileOrigin.latitude);
+        int firstCol = Tile.computeColumn(dLon, sector.minLongitude(), tileOrigin.longitude);
+        int lastCol = Tile.computeLastColumn(dLon, sector.maxLongitude(), tileOrigin.longitude);
 
         double deltaLat = dLat / 90;
         double d1 = sector.minLatPercent() + deltaLat * firstRow;
         for (int row = firstRow; row <= lastRow; row++) {
             double d2 = d1 + deltaLat;
-            double t1 = sector.minLongitude() + (firstCol * dLon);
+            double t1 = tileOrigin.longitude + (firstCol * dLon);
             for (int col = firstCol; col <= lastCol; col++) {
                 double t2;
                 t2 = t1 + dLon;

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorSector.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorSector.java
@@ -1,0 +1,47 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import gov.nasa.worldwind.geom.Sector;
+
+public class MercatorSector extends Sector {
+
+    private final double minLatPercent, maxLatPercent;
+
+    private MercatorSector(double minLatPercent, double maxLatPercent,
+                           double minLongitude, double maxLongitude) {
+        this.minLatPercent = minLatPercent;
+        this.maxLatPercent = maxLatPercent;
+        this.minLatitude = gudermannian(minLatPercent);
+        this.maxLatitude = gudermannian(maxLatPercent);
+        this.minLongitude = minLongitude;
+        this.maxLongitude = maxLongitude;
+    }
+
+    public static MercatorSector fromDegrees(double minLatPercent, double maxLatPercent,
+                                             double minLongitude, double maxLongitude) {
+        return new MercatorSector(minLatPercent, maxLatPercent, minLongitude, maxLongitude);
+    }
+
+    static MercatorSector fromSector(Sector sector) {
+        return new MercatorSector(gudermannianInverse(sector.minLatitude()),
+                gudermannianInverse(sector.maxLatitude()),
+                sector.minLongitude(), sector.maxLongitude());
+    }
+
+    static double gudermannianInverse(double latitude) {
+        return Math.log(Math.tan(Math.PI / 4.0 + Math.toRadians(latitude) / 2.0)) / Math.PI;
+    }
+
+    private static double gudermannian(double percent) {
+        return Math.toDegrees(Math.atan(Math.sinh(percent * Math.PI)));
+    }
+
+    double minLatPercent() {
+        return minLatPercent;
+    }
+
+    double maxLatPercent()
+    {
+        return maxLatPercent;
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorSector.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorSector.java
@@ -6,8 +6,7 @@ public class MercatorSector extends Sector {
 
     private final double minLatPercent, maxLatPercent;
 
-    private MercatorSector(double minLatPercent, double maxLatPercent,
-                           double minLongitude, double maxLongitude) {
+    public MercatorSector(double minLatPercent, double maxLatPercent, double minLongitude, double maxLongitude) {
         this.minLatPercent = minLatPercent;
         this.maxLatPercent = maxLatPercent;
         this.minLatitude = gudermannian(minLatPercent);

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
@@ -1,0 +1,44 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Sector;
+import gov.nasa.worldwind.layer.RenderableLayer;
+import gov.nasa.worldwind.render.ImageOptions;
+import gov.nasa.worldwind.render.ImageSource;
+import gov.nasa.worldwind.util.Level;
+import gov.nasa.worldwind.util.LevelSet;
+import gov.nasa.worldwind.util.Tile;
+import gov.nasa.worldwind.util.TileFactory;
+
+public abstract class MercatorTiledImageLayer extends RenderableLayer implements TileFactory {
+
+    private static final double FULL_SPHERE = 360;
+
+    private final int firstLevelOffset;
+
+    public MercatorTiledImageLayer(String name, int numLevels, int firstLevelOffset, int tileSize, boolean overlay) {
+        super(name);
+        this.setPickEnabled(false);
+        this.firstLevelOffset = firstLevelOffset;
+
+        MercatorTiledSurfaceImage surfaceImage = new MercatorTiledSurfaceImage();
+        surfaceImage.setLevelSet(new LevelSet(
+                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2),
+                FULL_SPHERE / (1 << firstLevelOffset), numLevels - firstLevelOffset, tileSize, tileSize));
+        surfaceImage.setTileFactory(this);
+        if(!overlay) {
+            surfaceImage.setImageOptions(new ImageOptions(WorldWind.RGB_565)); // reduce memory usage by using a 16-bit configuration with no alpha
+        }
+        this.addRenderable(surfaceImage);
+    }
+
+    @Override
+    public Tile createTile(Sector sector, Level level, int row, int column) {
+        MercatorImageTile tile = new MercatorImageTile((MercatorSector) sector, level, row, column);
+        tile.setImageSource(ImageSource.fromUrl(getImageSourceUrl(column, (1 << (level.levelNumber + firstLevelOffset)) - 1 - row, level.levelNumber + firstLevelOffset), tile));
+        return tile;
+    }
+
+    protected abstract String getImageSourceUrl(int x, int y, int z);
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
@@ -1,6 +1,7 @@
 package gov.nasa.worldwind.layer.mercator;
 
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.layer.RenderableLayer;
 import gov.nasa.worldwind.render.ImageOptions;
@@ -23,7 +24,7 @@ public abstract class MercatorTiledImageLayer extends RenderableLayer implements
 
         MercatorTiledSurfaceImage surfaceImage = new MercatorTiledSurfaceImage();
         surfaceImage.setLevelSet(new LevelSet(
-                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2),
+                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2), new Location(-90, -180),
                 FULL_SPHERE / (1 << firstLevelOffset), numLevels - firstLevelOffset, tileSize, tileSize));
         surfaceImage.setTileFactory(this);
         if(!overlay) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledImageLayer.java
@@ -13,8 +13,6 @@ import gov.nasa.worldwind.util.TileFactory;
 
 public abstract class MercatorTiledImageLayer extends RenderableLayer implements TileFactory {
 
-    private static final double FULL_SPHERE = 360;
-
     private final int firstLevelOffset;
 
     public MercatorTiledImageLayer(String name, int numLevels, int firstLevelOffset, int tileSize, boolean overlay) {
@@ -22,10 +20,12 @@ public abstract class MercatorTiledImageLayer extends RenderableLayer implements
         this.setPickEnabled(false);
         this.firstLevelOffset = firstLevelOffset;
 
+        MercatorSector sector = new MercatorSector(-1.0, 1.0, -180.0, 180.0);
+        Location tileOrigin = new Location(sector.minLatitude(), sector.minLongitude());
+        int n = 1 << firstLevelOffset;
+        Location firstLevelDelta = new Location(sector.deltaLatitude() / n, sector.deltaLongitude() / n);
         MercatorTiledSurfaceImage surfaceImage = new MercatorTiledSurfaceImage();
-        surfaceImage.setLevelSet(new LevelSet(
-                MercatorSector.fromDegrees(-1.0, 1.0, - FULL_SPHERE / 2, FULL_SPHERE / 2), new Location(-90, -180),
-                FULL_SPHERE / (1 << firstLevelOffset), numLevels - firstLevelOffset, tileSize, tileSize));
+        surfaceImage.setLevelSet(new LevelSet(sector, tileOrigin, firstLevelDelta, numLevels - firstLevelOffset, tileSize, tileSize));
         surfaceImage.setTileFactory(this);
         if(!overlay) {
             surfaceImage.setImageOptions(new ImageOptions(WorldWind.RGB_565)); // reduce memory usage by using a 16-bit configuration with no alpha

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledSurfaceImage.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/MercatorTiledSurfaceImage.java
@@ -1,0 +1,16 @@
+package gov.nasa.worldwind.layer.mercator;
+
+import gov.nasa.worldwind.shape.TiledSurfaceImage;
+import gov.nasa.worldwind.util.Level;
+
+public class MercatorTiledSurfaceImage extends TiledSurfaceImage {
+
+    @Override
+    protected void createTopLevelTiles() {
+        Level firstLevel = this.levelSet.firstLevel();
+        if (firstLevel != null) {
+            MercatorImageTile.assembleMercatorTilesForLevel(firstLevel, this.tileFactory, this.topLevelTiles);
+        }
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/google/GoogleLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/google/GoogleLayer.java
@@ -1,0 +1,39 @@
+package gov.nasa.worldwind.layer.mercator.google;
+
+import gov.nasa.worldwind.layer.mercator.MercatorTiledImageLayer;
+
+public class GoogleLayer extends MercatorTiledImageLayer {
+
+    public GoogleLayer(Type type) {
+        super(type.layerName, 22, 0, 256, type.overlay);
+        this.lyrs = type.lyrs;
+    }
+
+    private final String lyrs;
+
+    public enum Type {
+        ROADMAP("Google road map", "m", false),
+        ROADMAP2("Google road map 2", "r", false),
+        TERRAIN("Google map w/ terrain", "p", false),
+        TERRAIN_ONLY("Google terrain only", "t", false),
+        HYBRID("Google hybrid", "y", false),
+        SATELLITE("Google satellite", "s", false),
+        ROADS("Google roads", "h", true),
+        TRAFFIC("Google traffic", "h,traffic&style=15", true);
+
+        private final String layerName;
+        private final String lyrs;
+        private final boolean overlay;
+
+        Type(String layerName, String lyrs, boolean overlay) {
+            this.layerName = layerName;
+            this.lyrs = lyrs;
+            this.overlay = overlay;
+        }
+    }
+
+    @Override
+    public String getImageSourceUrl(int x, int y, int z) {
+        return "https://mt.google.com/vt/lyrs="+lyrs+"&x="+x+"&y="+y+"&z="+z+"&hl=ru";
+    }
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/osm/OSMLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/osm/OSMLayer.java
@@ -1,0 +1,23 @@
+package gov.nasa.worldwind.layer.mercator.osm;
+
+import java.util.Random;
+
+import gov.nasa.worldwind.layer.mercator.MercatorTiledImageLayer;
+
+public class OSMLayer extends MercatorTiledImageLayer {
+
+    public static final String NAME = "OpenStreetMap";
+
+    private final Random random = new Random();
+
+    public OSMLayer() {
+        super(NAME, 20, 3, 256, false);
+    }
+
+    @Override
+    protected String getImageSourceUrl(int x, int y, int z) {
+        char abc = "abc".charAt(random.nextInt(2));
+        return "https://"+abc+".tile.openstreetmap.org/"+z+"/"+x+"/"+y+".png";
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/osm/OTMLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/osm/OTMLayer.java
@@ -1,0 +1,23 @@
+package gov.nasa.worldwind.layer.mercator.osm;
+
+import java.util.Random;
+
+import gov.nasa.worldwind.layer.mercator.MercatorTiledImageLayer;
+
+public class OTMLayer extends MercatorTiledImageLayer {
+
+    public static final String NAME = "OpenTopoMap";
+
+    private final Random random = new Random();
+
+    public OTMLayer() {
+        super(NAME, 18, 3, 256, false);
+    }
+
+    @Override
+    protected String getImageSourceUrl(int x, int y, int z) {
+        char abc = "abc".charAt(random.nextInt(2));
+        return "https://"+abc+".tile.opentopomap.org/"+z+"/"+x+"/"+y+".png";
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/wiki/WikiLayer.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/layer/mercator/wiki/WikiLayer.java
@@ -1,0 +1,24 @@
+package gov.nasa.worldwind.layer.mercator.wiki;
+
+import gov.nasa.worldwind.layer.mercator.MercatorTiledImageLayer;
+
+public class WikiLayer extends MercatorTiledImageLayer {
+
+    public enum Type { MAP, HYBRID }
+
+    public static final String NAME = "Wiki";
+
+    private final Type type;
+
+    public WikiLayer(Type type) {
+        super(NAME + type.name().toLowerCase(), 23, 3, 256, Type.HYBRID == type);
+        this.type = type;
+    }
+
+    @Override
+    protected String getImageSourceUrl(int x, int y, int z) {
+        int i = x % 4 + y % 4 * 4;
+        return "http://i"+i+".wikimapia.org/?lng=1&x="+x+"&y="+y+"&zoom="+z+"&type="+type.name().toLowerCase();
+    }
+
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/ImageSource.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/ImageSource.java
@@ -50,6 +50,18 @@ public class ImageSource {
         Bitmap createBitmap();
     }
 
+    /**
+     * Interface for remote image source post-transformation
+     */
+    public interface Transformer {
+        /**
+         * Transforms image according to specified algorithm implementation
+         * @param bitmap original bitmap
+         * @return transformed bitmap
+         */
+        Bitmap transform(Bitmap bitmap);
+    }
+
     protected static final HashMap<Object, BitmapFactory> lineStippleFactories = new HashMap<>();
 
     protected static final int TYPE_UNRECOGNIZED = 0;
@@ -67,6 +79,8 @@ public class ImageSource {
     protected int type = TYPE_UNRECOGNIZED;
 
     protected Object source;
+
+    protected Transformer transformer;
 
     protected ImageSource() {
     }
@@ -170,6 +184,23 @@ public class ImageSource {
         ImageSource imageSource = new ImageSource();
         imageSource.type = TYPE_URL;
         imageSource.source = urlString;
+        return imageSource;
+    }
+
+    /**
+     * Constructs an image source with a URL string. The image's dimensions should be no greater than 2048 x 2048. The
+     * application's manifest must include the permissions that allow network connections.
+     *
+     * @param urlString complete URL string
+     * @param transformer implementation of image post-transformation routine
+     *
+     * @return the new image source
+     *
+     * @throws IllegalArgumentException If the URL string is null
+     */
+    public static ImageSource fromUrl(String urlString, Transformer transformer) {
+        ImageSource imageSource = fromUrl(urlString);
+        imageSource.transformer = transformer;
         return imageSource;
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/ImageSource.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/ImageSource.java
@@ -12,6 +12,7 @@ import android.support.annotation.DrawableRes;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import gov.nasa.worldwind.util.DownloadPostprocessor;
 import gov.nasa.worldwind.util.Logger;
 import gov.nasa.worldwind.util.WWUtil;
 
@@ -67,6 +68,8 @@ public class ImageSource {
     protected int type = TYPE_UNRECOGNIZED;
 
     protected Object source;
+
+    protected DownloadPostprocessor<Bitmap> postprocessor;
 
     protected ImageSource() {
     }
@@ -170,6 +173,23 @@ public class ImageSource {
         ImageSource imageSource = new ImageSource();
         imageSource.type = TYPE_URL;
         imageSource.source = urlString;
+        return imageSource;
+    }
+
+    /**
+     * Constructs an image source with a URL string. The image's dimensions should be no greater than 2048 x 2048. The
+     * application's manifest must include the permissions that allow network connections.
+     *
+     * @param urlString complete URL string
+     * @param postprocessor implementation of image post-transformation routine
+     *
+     * @return the new image source
+     *
+     * @throws IllegalArgumentException If the URL string is null
+     */
+    public static ImageSource fromUrl(String urlString, DownloadPostprocessor<Bitmap> postprocessor) {
+        ImageSource imageSource = fromUrl(urlString);
+        imageSource.postprocessor = postprocessor;
         return imageSource;
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/DownloadPostprocessor.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/DownloadPostprocessor.java
@@ -1,0 +1,14 @@
+package gov.nasa.worldwind.util;
+
+/**
+ * Interface for resource download post-processing
+ */
+public interface DownloadPostprocessor<T> {
+    /**
+     * Process resource according to specified algorithm implementation
+     *
+     * @param resource original resource
+     * @return processed resource
+     */
+    T process(T resource);
+}

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
@@ -67,8 +67,8 @@ public class Level {
 
         this.parent = parent;
         this.levelNumber = levelNumber;
-        this.levelWidth = (int) Math.round(parent.tileWidth * 360 / tileDelta);
-        this.levelHeight = (int) Math.round(parent.tileHeight * 180 / tileDelta);
+        this.levelWidth = (int) Math.round(parent.tileWidth * parent.sector.deltaLongitude() / tileDelta);
+        this.levelHeight = (int) Math.round(parent.tileHeight * parent.sector.deltaLatitude() / tileDelta);
         this.tileDelta = tileDelta;
         this.tileWidth = parent.tileWidth;
         this.tileHeight = parent.tileHeight;

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Level.java
@@ -5,6 +5,8 @@
 
 package gov.nasa.worldwind.util;
 
+import gov.nasa.worldwind.geom.Location;
+
 /**
  * Represents a level of a specific resolution in a {@link LevelSet}.
  */
@@ -35,7 +37,7 @@ public class Level {
     /**
      * The geographic width and height in degrees of tiles within this level.
      */
-    public final double tileDelta;
+    public final Location tileDelta;
 
     /**
      * The parent LevelSet's tileWidth.
@@ -54,21 +56,21 @@ public class Level {
      * @param levelNumber the level's ordinal within its parent level set
      * @param tileDelta   the geographic width and height in degrees of tiles within this level
      */
-    public Level(LevelSet parent, int levelNumber, double tileDelta) {
+    public Level(LevelSet parent, int levelNumber, Location tileDelta) {
         if (parent == null) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "Level", "constructor", "The parent level set is null"));
         }
 
-        if (tileDelta <= 0) {
+        if (tileDelta == null || tileDelta.latitude <= 0 || tileDelta.longitude <= 0) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "Level", "constructor", "The tile delta is zero"));
         }
 
         this.parent = parent;
         this.levelNumber = levelNumber;
-        this.levelWidth = (int) Math.round(parent.tileWidth * parent.sector.deltaLongitude() / tileDelta);
-        this.levelHeight = (int) Math.round(parent.tileHeight * parent.sector.deltaLatitude() / tileDelta);
+        this.levelWidth = (int) Math.round(parent.tileWidth * parent.sector.deltaLongitude() / tileDelta.longitude);
+        this.levelHeight = (int) Math.round(parent.tileHeight * parent.sector.deltaLatitude() / tileDelta.latitude);
         this.tileDelta = tileDelta;
         this.tileWidth = parent.tileWidth;
         this.tileHeight = parent.tileHeight;

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSet.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSet.java
@@ -204,7 +204,7 @@ public class LevelSet {
         }
 
         double degreesPerPixel = Math.toDegrees(radiansPerPixel);
-        double firstLevelDegreesPerPixel = Math.max(this.firstLevelDelta.longitude / this.tileWidth, this.firstLevelDelta.latitude / this.tileHeight);
+        double firstLevelDegreesPerPixel = this.firstLevelDelta.latitude / this.tileHeight;
         double level = Math.log(firstLevelDegreesPerPixel / degreesPerPixel) / Math.log(2); // fractional level address
         int levelNumber = (int) Math.round(level); // nearest neighbor level
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSet.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSet.java
@@ -5,6 +5,7 @@
 
 package gov.nasa.worldwind.util;
 
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 
 /**
@@ -17,6 +18,11 @@ public class LevelSet {
      * The sector spanned by this level set.
      */
     public final Sector sector = new Sector();
+
+    /**
+     * Tile origin for this level set
+     */
+    public final Location tileOrigin = new Location();
 
     /**
      * The geographic width and height in degrees of tiles in the first level (lowest resolution) of this level set.
@@ -55,6 +61,7 @@ public class LevelSet {
      * Constructs a level set with specified parameters.
      *
      * @param sector          the sector spanned by this level set
+     * @param tileOrigin      the origin for this level set
      * @param firstLevelDelta the geographic width and height in degrees of tiles in the first level (lowest resolution)
      *                        of the level set
      * @param numLevels       the number of levels in the level set
@@ -67,10 +74,15 @@ public class LevelSet {
      *
      * @throws IllegalArgumentException If any argument is null, or if any dimension is zero
      */
-    public LevelSet(Sector sector, double firstLevelDelta, int numLevels, int tileWidth, int tileHeight) {
+    public LevelSet(Sector sector, Location tileOrigin, double firstLevelDelta, int numLevels, int tileWidth, int tileHeight) {
         if (sector == null) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingSector"));
+        }
+
+        if (tileOrigin == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingTileOrigin"));
         }
 
         if (firstLevelDelta <= 0) {
@@ -89,6 +101,7 @@ public class LevelSet {
         }
 
         this.sector.set(sector);
+        this.tileOrigin.set(tileOrigin);
         this.firstLevelDelta = firstLevelDelta;
         this.tileWidth = tileWidth;
         this.tileHeight = tileHeight;
@@ -116,6 +129,11 @@ public class LevelSet {
                 Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingSector"));
         }
 
+        if (config.tileOrigin == null) {
+            throw new IllegalArgumentException(
+                    Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "missingTileOrigin"));
+        }
+
         if (config.firstLevelDelta <= 0) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "LevelSet", "constructor", "invalidTileDelta"));
@@ -132,6 +150,7 @@ public class LevelSet {
         }
 
         this.sector.set(config.sector);
+        this.tileOrigin.set(config.tileOrigin);
         this.firstLevelDelta = config.firstLevelDelta;
         this.tileWidth = config.tileWidth;
         this.tileHeight = config.tileHeight;
@@ -141,8 +160,7 @@ public class LevelSet {
 
     protected void assembleLevels() {
         for (int i = 0, len = this.levels.length; i < len; i++) {
-            double n = Math.pow(2, i);
-            double delta = firstLevelDelta / n;
+            double delta = firstLevelDelta / (1 << i);
             this.levels[i] = new Level(this, i, delta);
         }
     }

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
@@ -97,7 +97,7 @@ public class LevelSetConfig {
         }
 
         double degreesPerPixel = Math.toDegrees(radiansPerPixel);
-        double firstLevelDegreesPerPixel = Math.max(this.firstLevelDelta.longitude / this.tileWidth, this.firstLevelDelta.latitude / this.tileHeight);
+        double firstLevelDegreesPerPixel = this.firstLevelDelta.latitude / this.tileHeight;
         double level = Math.log(firstLevelDegreesPerPixel / degreesPerPixel) / Math.log(2); // fractional level address
         int levelNumber = (int) Math.ceil(level); // ceiling captures the resolution
 
@@ -126,7 +126,7 @@ public class LevelSetConfig {
         }
 
         double degreesPerPixel = Math.toDegrees(radiansPerPixel);
-        double firstLevelDegreesPerPixel = Math.max(this.firstLevelDelta.longitude / this.tileWidth, this.firstLevelDelta.latitude / this.tileHeight);
+        double firstLevelDegreesPerPixel = this.firstLevelDelta.latitude / this.tileHeight;
         double level = Math.log(firstLevelDegreesPerPixel / degreesPerPixel) / Math.log(2); // fractional level address
         int levelNumber = (int) Math.floor(level); // floor prevents exceeding the min scale
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
@@ -5,6 +5,7 @@
 
 package gov.nasa.worldwind.util;
 
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 
 /**
@@ -17,6 +18,11 @@ public class LevelSetConfig {
      * The sector spanned by the level set.
      */
     public final Sector sector = new Sector().setFullSphere();
+
+    /**
+     * Tile origin for level set
+     */
+    public final Location tileOrigin = new Location(-90, -180);
 
     /**
      * The geographic width and height in degrees of tiles in the first level (lowest resolution) of the level set.

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/LevelSetConfig.java
@@ -25,9 +25,9 @@ public class LevelSetConfig {
     public final Location tileOrigin = new Location(-90, -180);
 
     /**
-     * The geographic width and height in degrees of tiles in the first level (lowest resolution) of the level set.
+     * The geographic width and height in degrees of tiles in the first level (the lowest resolution) of the level set.
      */
-    public double firstLevelDelta = 90;
+    public final Location firstLevelDelta = new Location(90, 90);
 
     /**
      * The number of levels in the level set.
@@ -69,12 +69,12 @@ public class LevelSetConfig {
      *                        sample points in the latitudinal direction of elevation tiles associate with the level
      *                        set
      */
-    public LevelSetConfig(Sector sector, double firstLevelDelta, int numLevels, int tileWidth, int tileHeight) {
+    public LevelSetConfig(Sector sector, Location firstLevelDelta, int numLevels, int tileWidth, int tileHeight) {
         if (sector != null) {
             this.sector.set(sector);
         }
 
-        this.firstLevelDelta = firstLevelDelta;
+        this.firstLevelDelta.set(firstLevelDelta);
         this.numLevels = numLevels;
         this.tileWidth = tileWidth;
         this.tileHeight = tileHeight;
@@ -97,7 +97,7 @@ public class LevelSetConfig {
         }
 
         double degreesPerPixel = Math.toDegrees(radiansPerPixel);
-        double firstLevelDegreesPerPixel = this.firstLevelDelta / Math.min(this.tileWidth, this.tileHeight);
+        double firstLevelDegreesPerPixel = Math.max(this.firstLevelDelta.longitude / this.tileWidth, this.firstLevelDelta.latitude / this.tileHeight);
         double level = Math.log(firstLevelDegreesPerPixel / degreesPerPixel) / Math.log(2); // fractional level address
         int levelNumber = (int) Math.ceil(level); // ceiling captures the resolution
 
@@ -126,7 +126,7 @@ public class LevelSetConfig {
         }
 
         double degreesPerPixel = Math.toDegrees(radiansPerPixel);
-        double firstLevelDegreesPerPixel = this.firstLevelDelta / this.tileHeight;
+        double firstLevelDegreesPerPixel = Math.max(this.firstLevelDelta.longitude / this.tileWidth, this.firstLevelDelta.latitude / this.tileHeight);
         double level = Math.log(firstLevelDegreesPerPixel / degreesPerPixel) / Math.log(2); // fractional level address
         int levelNumber = (int) Math.floor(level); // floor prevents exceeding the min scale
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -109,7 +109,7 @@ public class Tile {
         this.row = row;
         this.column = column;
         this.tileKey = level.levelNumber + "." + row + "." + column;
-        this.texelSizeFactor = Math.toRadians(level.tileDelta / level.tileWidth) * Math.cos(Math.toRadians(sector.centroidLatitude()));
+        this.texelSizeFactor = Math.toRadians(level.tileDelta.longitude / level.tileWidth) * Math.cos(Math.toRadians(sector.centroidLatitude()));
     }
 
     /**
@@ -217,29 +217,25 @@ public class Tile {
 
         Sector sector = level.parent.sector;
         Location tileOrigin = level.parent.tileOrigin;
-        double tileDelta = level.tileDelta;
+        Location tileDelta = level.tileDelta;
 
-        int firstRow = Tile.computeRow(tileDelta, sector.minLatitude(), tileOrigin.latitude);
-        int lastRow = Tile.computeLastRow(tileDelta, sector.maxLatitude(), tileOrigin.latitude);
-        int firstCol = Tile.computeColumn(tileDelta, sector.minLongitude(), tileOrigin.longitude);
-        int lastCol = Tile.computeLastColumn(tileDelta, sector.maxLongitude(), tileOrigin.longitude);
+        int firstRow = Tile.computeRow(tileDelta.latitude, sector.minLatitude(), tileOrigin.latitude);
+        int lastRow = Tile.computeLastRow(tileDelta.latitude, sector.maxLatitude(), tileOrigin.latitude);
+        int firstCol = Tile.computeColumn(tileDelta.longitude, sector.minLongitude(), tileOrigin.longitude);
+        int lastCol = Tile.computeLastColumn(tileDelta.longitude, sector.maxLongitude(), tileOrigin.longitude);
 
-        double firstRowLat = tileOrigin.latitude + firstRow * tileDelta;
-        double firstRowLon = tileOrigin.longitude + firstCol * tileDelta;
+        double firstRowLat = tileOrigin.latitude + firstRow * tileDelta.latitude;
+        double firstColLon = tileOrigin.longitude + firstCol * tileDelta.longitude;
+
         double lat = firstRowLat;
-        double lon;
-
         for (int row = firstRow; row <= lastRow; row++) {
-            lon = firstRowLon;
-
+            double lon = firstColLon;
             for (int col = firstCol; col <= lastCol; col++) {
-                Sector tileSector = new Sector(lat, lon, tileDelta, tileDelta);
+                Sector tileSector = new Sector(lat, lon, tileDelta.latitude, tileDelta.longitude);
                 result.add(tileFactory.createTile(tileSector, level, row, col));
-
-                lon += tileDelta;
+                lon += tileDelta.longitude;
             }
-
-            lat += tileDelta;
+            lat += tileDelta.latitude;
         }
 
         return result;
@@ -334,26 +330,27 @@ public class Tile {
         double lonMin = this.sector.minLongitude();
         double latMid = this.sector.centroidLatitude();
         double lonMid = this.sector.centroidLongitude();
-        double childDelta = this.level.tileDelta * 0.5;
+        double childDeltaLat = this.level.tileDelta.latitude * 0.5;
+        double childDeltaLon = this.level.tileDelta.longitude * 0.5;
 
         int childRow = 2 * this.row;
         int childCol = 2 * this.column;
-        Sector childSector = new Sector(latMin, lonMin, childDelta, childDelta);
+        Sector childSector = new Sector(latMin, lonMin, childDeltaLat, childDeltaLon);
         children[0] = tileFactory.createTile(childSector, childLevel, childRow, childCol); // Southwest
 
         childRow = 2 * this.row;
         childCol = 2 * this.column + 1;
-        childSector = new Sector(latMin, lonMid, childDelta, childDelta);
+        childSector = new Sector(latMin, lonMid, childDeltaLat, childDeltaLon);
         children[1] = tileFactory.createTile(childSector, childLevel, childRow, childCol); // Southeast
 
         childRow = 2 * this.row + 1;
         childCol = 2 * this.column;
-        childSector = new Sector(latMid, lonMin, childDelta, childDelta);
+        childSector = new Sector(latMid, lonMin, childDeltaLat, childDeltaLon);
         children[2] = tileFactory.createTile(childSector, childLevel, childRow, childCol); // Northwest
 
         childRow = 2 * this.row + 1;
         childCol = 2 * this.column + 1;
-        childSector = new Sector(latMid, lonMid, childDelta, childDelta);
+        childSector = new Sector(latMid, lonMid, childDeltaLat, childDeltaLon);
         children[3] = tileFactory.createTile(childSector, childLevel, childRow, childCol); // Northeast
 
         return children;

--- a/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/util/Tile.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.geom.BoundingBox;
 import gov.nasa.worldwind.geom.Frustum;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.geom.Vec3;
 import gov.nasa.worldwind.render.RenderContext;
@@ -116,13 +117,14 @@ public class Tile {
      *
      * @param tileDelta the level's tile delta in degrees
      * @param latitude  the tile's minimum latitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return the computed row number
      */
-    public static int computeRow(double tileDelta, double latitude) {
-        int row = (int) Math.floor((latitude + 90) / tileDelta);
+    public static int computeRow(double tileDelta, double latitude, double origin) {
+        int row = (int) Math.floor((latitude - origin) / tileDelta);
 
-        if (latitude == 90) {
+        if (latitude - origin == 180) {
             row -= 1; // if latitude is at the end of the grid, subtract 1 from the computed row to return the last row
         }
 
@@ -134,13 +136,14 @@ public class Tile {
      *
      * @param tileDelta the level's tile delta in degrees
      * @param longitude the tile's minimum longitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return The computed column number
      */
-    public static int computeColumn(double tileDelta, double longitude) {
-        int col = (int) Math.floor((longitude + 180) / tileDelta);
+    public static int computeColumn(double tileDelta, double longitude, double origin) {
+        int col = (int) Math.floor((longitude - origin) / tileDelta);
 
-        if (longitude == 180) {
+        if (longitude - origin == 360) {
             col -= 1; // if longitude is at the end of the grid, subtract 1 from the computed column to return the last column
         }
 
@@ -152,13 +155,14 @@ public class Tile {
      *
      * @param tileDelta   the level's tile delta in degrees
      * @param maxLatitude the tile's maximum latitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return the computed row number
      */
-    public static int computeLastRow(double tileDelta, double maxLatitude) {
-        int row = (int) Math.ceil((maxLatitude + 90) / tileDelta - 1);
+    public static int computeLastRow(double tileDelta, double maxLatitude, double origin) {
+        int row = (int) Math.ceil((maxLatitude - origin) / tileDelta - 1);
 
-        if (maxLatitude + 90 < tileDelta) {
+        if (maxLatitude - origin < tileDelta) {
             row = 0; // if max latitude is in the first row, set the max row to 0
         }
 
@@ -170,13 +174,14 @@ public class Tile {
      *
      * @param tileDelta    the level's tile delta in degrees
      * @param maxLongitude the tile's maximum longitude in degrees
+     * @param origin    the origin of the grid
      *
      * @return The computed column number
      */
-    public static int computeLastColumn(double tileDelta, double maxLongitude) {
-        int col = (int) Math.ceil((maxLongitude + 180) / tileDelta - 1);
+    public static int computeLastColumn(double tileDelta, double maxLongitude, double origin) {
+        int col = (int) Math.ceil((maxLongitude - origin) / tileDelta - 1);
 
-        if (maxLongitude + 180 < tileDelta) {
+        if (maxLongitude - origin < tileDelta) {
             col = 0; // if max longitude is in the first column, set the max column to 0
         }
 
@@ -211,15 +216,16 @@ public class Tile {
         }
 
         Sector sector = level.parent.sector;
+        Location tileOrigin = level.parent.tileOrigin;
         double tileDelta = level.tileDelta;
 
-        int firstRow = Tile.computeRow(tileDelta, sector.minLatitude());
-        int lastRow = Tile.computeLastRow(tileDelta, sector.maxLatitude());
-        int firstCol = Tile.computeColumn(tileDelta, sector.minLongitude());
-        int lastCol = Tile.computeLastColumn(tileDelta, sector.maxLongitude());
+        int firstRow = Tile.computeRow(tileDelta, sector.minLatitude(), tileOrigin.latitude);
+        int lastRow = Tile.computeLastRow(tileDelta, sector.maxLatitude(), tileOrigin.latitude);
+        int firstCol = Tile.computeColumn(tileDelta, sector.minLongitude(), tileOrigin.longitude);
+        int lastCol = Tile.computeLastColumn(tileDelta, sector.maxLongitude(), tileOrigin.longitude);
 
-        double firstRowLat = -90 + firstRow * tileDelta;
-        double firstRowLon = -180 + firstCol * tileDelta;
+        double firstRowLat = tileOrigin.latitude + firstRow * tileDelta;
+        double firstRowLon = tileOrigin.longitude + firstCol * tileDelta;
         double lat = firstRowLat;
         double lon;
 

--- a/worldwind/src/test/java/gov/nasa/worldwind/globe/BasicTerrainTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/globe/BasicTerrainTest.java
@@ -14,6 +14,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Location;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.geom.Vec3;
 import gov.nasa.worldwind.util.LevelSet;
@@ -81,7 +82,7 @@ public class BasicTerrainTest {
         this.terrain = new BasicTerrain();
 
         // Add a terrain tile used to the mocked terrain
-        LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), 1.0, 1, 5, 5); // tiles with 5x5 vertices
+        LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), 1.0, 1, 5, 5); // tiles with 5x5 vertices
         TerrainTile tile = new TerrainTile(new Sector(0, 0, 1, 1), levelSet.firstLevel(), 90, 180);
         ((BasicTerrain) this.terrain).addTile(tile);
 

--- a/worldwind/src/test/java/gov/nasa/worldwind/globe/BasicTerrainTest.java
+++ b/worldwind/src/test/java/gov/nasa/worldwind/globe/BasicTerrainTest.java
@@ -82,7 +82,7 @@ public class BasicTerrainTest {
         this.terrain = new BasicTerrain();
 
         // Add a terrain tile used to the mocked terrain
-        LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), 1.0, 1, 5, 5); // tiles with 5x5 vertices
+        LevelSet levelSet = new LevelSet(new Sector().setFullSphere(), new Location(-90, -180), new Location(1.0, 1.0), 1, 5, 5); // tiles with 5x5 vertices
         TerrainTile tile = new TerrainTile(new Sector(0, 0, 1, 1), levelSet.firstLevel(), 90, 180);
         ((BasicTerrain) this.terrain).addTile(tile);
 


### PR DESCRIPTION
### Description of the Change
Basic GeoPackage implementation does not support level sets started not in -90, -180 coordinates, but according standard any external system exports GeoPackage files with the tile origin equals south west corner of visible tile set.

That's why GeoPackage requires following improvements:
- Add support of local tile origin based on tile matrix set extent instead of full sphere origin.
- Add surface image name based on content identifier.
- Change level set sector initialization based on tile matrix set extent instead of content extent.
- Change first level tile delta and number of levels calculation based on tile matrix zoom levels.
- Fix row calculation in tile factory.

General API requires following improvements:
- Add tile origin attribute to level set.
- Enhance tile row and column calculation routines with tile origin parameter.
- Fix level width and height calculation in case of non-full sphere level set sector used.

This PR is based on Mercator PR https://github.com/NASAWorldWind/WorldWindAndroid/pull/242 due to this fix also related to MercatorTile calculations.

### Why Should This Be In Core?
Support of GeoPackage files exported from ArcGis or GlobalMapper is not possible without this improvements.
Now GeoPackage works only with WorldWind test example, which was made with violation of GeoPackage specification requirements. Other words GeoPackage implementation is wrong now. 

### Benefits
Adding correct support of EPSG 4326 GeoPackage offline cache.

### Potential Drawbacks
None. Backward compatible with current incorrect GeoPackage example. 