### PR TITLE
Fix/placemark rotation and tilt

### DIFF
--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksDemoActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksDemoActivity.java
@@ -142,9 +142,11 @@ public class PlacemarksDemoActivity extends GeneralGlobeActivity {
          * @param rc
          * @param placemark      The placemark needing a level of detail selection
          * @param cameraDistance The distance from the placemark to the camera (meters)
+         *
+         * @return if placemark should display or skip its rendering
          */
         @Override
-        public void selectLevelOfDetail(RenderContext rc, Placemark placemark, double cameraDistance) {
+        public boolean selectLevelOfDetail(RenderContext rc, Placemark placemark, double cameraDistance) {
 
             boolean highlighted = placemark.isHighlighted();
             boolean highlightChanged = this.lastHighlightState != highlighted;
@@ -213,7 +215,13 @@ public class PlacemarksDemoActivity extends GeneralGlobeActivity {
             this.lastHighlightState = highlighted;
 
             // Update the placemark's attributes bundle
-            placemark.setAttributes(this.attributes);
+            if (this.attributes != null) {
+                this.attributes.setDrawLabel(highlighted || cameraDistance <= LEVEL_1_DISTANCE);
+                placemark.setAttributes(this.attributes);
+                return true; // Placemark visible
+            } else {
+                return false; // Placemark invisible
+            }
         }
 
         protected static PlacemarkAttributes getPlacemarkAttributes(Resources resources, Place place) {

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksDemoActivity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksDemoActivity.java
@@ -30,6 +30,8 @@ import java.util.Locale;
 import gov.nasa.worldwind.BasicWorldWindowController;
 import gov.nasa.worldwind.PickedObject;
 import gov.nasa.worldwind.PickedObjectList;
+import gov.nasa.worldwind.WorldWind;
+import gov.nasa.worldwind.geom.Offset;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.layer.RenderableLayer;
 import gov.nasa.worldwind.render.ImageSource;
@@ -273,6 +275,7 @@ public class PlacemarksDemoActivity extends GeneralGlobeActivity {
             //IconBitmapFactory factory = new IconBitmapFactory(resources, resourceId);
             //placemarkAttributes.setImageSource(ImageSource.fromBitmapFactory(factory)).setImageScale(scale);
             placemarkAttributes.setImageSource(ImageSource.fromResource(resourceId)).setImageScale(scale).setMinimumImageScale(0.5);
+            placemarkAttributes.getLabelAttributes().setTextOffset(new Offset(WorldWind.OFFSET_PIXELS, -24, WorldWind.OFFSET_FRACTION, 0.0));
             return placemarkAttributes;
         }
     }
@@ -560,6 +563,8 @@ public class PlacemarksDemoActivity extends GeneralGlobeActivity {
                 placemark.setLevelOfDetailSelector(new PlaceLevelOfDetailSelector(getResources(), place));
                 placemark.setEyeDistanceScaling(true);
                 placemark.setEyeDistanceScalingThreshold(PlaceLevelOfDetailSelector.LEVEL_1_DISTANCE);
+                placemark.setLabel(place.name);
+                placemark.setAltitudeMode(WorldWind.CLAMP_TO_GROUND);
 
                 // On a background thread, we can add Placemarks to a RenderableLayer that is
                 // NOT attached to the WorldWindow. If the layer was attached to the WorldWindow

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksMilStd2525Activity.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/PlacemarksMilStd2525Activity.java
@@ -86,6 +86,7 @@ public class PlacemarksMilStd2525Activity extends GeneralGlobeActivity {
             Placemark drone = new Placemark(
                 Position.fromDegrees(32.4520, 63.44553, 3000),
                 MilStd2525.getPlacemarkAttributes("SFAPMFQM--GIUSA", modifiers, null));
+            drone.getAttributes().setDrawLeader(true);
 
             symbolLayer.addRenderable(drone);
 
@@ -96,6 +97,7 @@ public class PlacemarksMilStd2525Activity extends GeneralGlobeActivity {
             Placemark launcher = new Placemark(
                 Position.fromDegrees(32.4014, 63.3894, 0),
                 MilStd2525.getPlacemarkAttributes("SHGXUCFRMS----G", modifiers, null));
+            launcher.setAltitudeMode(WorldWind.CLAMP_TO_GROUND);
 
             symbolLayer.addRenderable(launcher);
 
@@ -109,6 +111,7 @@ public class PlacemarksMilStd2525Activity extends GeneralGlobeActivity {
             Placemark machineGun = new Placemark(
                 Position.fromDegrees(32.3902, 63.4161, 0),
                 MilStd2525.getPlacemarkAttributes("SFGPEWRH--MTUSG", modifiers, null));
+            machineGun.setAltitudeMode(WorldWind.CLAMP_TO_GROUND);
 
             symbolLayer.addRenderable(machineGun);
 

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/milstd2525/MilStd2525.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/milstd2525/MilStd2525.java
@@ -269,7 +269,8 @@ public class MilStd2525 {
             Rect bounds = imageInfo.getImageBounds();       // The extents of the image, including text modifiers
             this.placemarkOffset = new Offset(
                 WorldWind.OFFSET_PIXELS, centerPoint.x, // x offset
-                WorldWind.OFFSET_PIXELS, bounds.height() - centerPoint.y); // y offset converted to lower-left origin
+                // Use billboarding or lollipopping to prevent icon clipping by terrain as described in MIL-STD-2525C APPENDIX F.5.1.1.2
+                WorldWind.OFFSET_PIXELS, 0/*bounds.height() - centerPoint.y*/); // y offset converted to lower-left origin
 
             // Apply the placemark offset to the attributes on the main thread. This is necessary to synchronize write
             // access to placemarkAttributes from the thread that invokes this BitmapFactory and read access from the

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/milstd2525/MilStd2525.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/milstd2525/MilStd2525.java
@@ -10,7 +10,6 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Point;
-import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Handler;
 import android.os.Looper;
@@ -266,7 +265,7 @@ public class MilStd2525 {
             // placement as the offset may change depending on the level of detail, for instance, the absence or
             // presence of text modifiers.
             Point centerPoint = imageInfo.getCenterPoint(); // The center of the core symbol
-            Rect bounds = imageInfo.getImageBounds();       // The extents of the image, including text modifiers
+            //Rect bounds = imageInfo.getImageBounds();       // The extents of the image, including text modifiers
             this.placemarkOffset = new Offset(
                 WorldWind.OFFSET_PIXELS, centerPoint.x, // x offset
                 // Use billboarding or lollipopping to prevent icon clipping by terrain as described in MIL-STD-2525C APPENDIX F.5.1.1.2

--- a/worldwind-examples/src/main/java/gov/nasa/worldwindx/milstd2525/MilStd2525LevelOfDetailSelector.java
+++ b/worldwind-examples/src/main/java/gov/nasa/worldwindx/milstd2525/MilStd2525LevelOfDetailSelector.java
@@ -59,9 +59,11 @@ public class MilStd2525LevelOfDetailSelector implements Placemark.LevelOfDetailS
      * @param rc             The current render contents
      * @param placemark      The placemark needing a level of detail selection
      * @param cameraDistance The distance from the placemark to the camera (meters)
+     *
+     * @return if placemark should display or skip its rendering
      */
     @Override
-    public void selectLevelOfDetail(RenderContext rc, Placemark placemark, double cameraDistance) {
+    public boolean selectLevelOfDetail(RenderContext rc, Placemark placemark, double cameraDistance) {
         if (!(placemark instanceof MilStd2525Placemark)) {
             throw new IllegalArgumentException(
                 Logger.logMessage(Logger.ERROR, "MilStd2525LevelOfDetailSelector", "selectLevelOfDetail",
@@ -108,5 +110,7 @@ public class MilStd2525LevelOfDetailSelector implements Placemark.LevelOfDetailS
         if (this.placemarkAttributes != null) {
             milStdPlacemark.setAttributes(this.placemarkAttributes);
         }
+
+        return true; // Placemark is always visible
     }
 }

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
@@ -432,7 +432,7 @@ public class RenderContext {
     }
 
     public Texture renderText(String text, TextAttributes attributes) {
-        TextCacheKey key = new TextCacheKey().set(text, attributes);
+        TextCacheKey key = this.scratchTextCacheKey.set(text, attributes);
         Texture texture = null;
 
         if (text != null && attributes != null) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/render/RenderContext.java
@@ -432,7 +432,7 @@ public class RenderContext {
     }
 
     public Texture renderText(String text, TextAttributes attributes) {
-        TextCacheKey key = this.scratchTextCacheKey.set(text, attributes);
+        TextCacheKey key = new TextCacheKey().set(text, attributes);
         Texture texture = null;
 
         if (text != null && attributes != null) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Label.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Label.java
@@ -445,10 +445,11 @@ public class Label extends AbstractRenderable implements Highlightable, Movable 
         // origin at the text's bottom-left corner and axes that extend up and to the right from the origin point.
         int w = texture.getWidth();
         int h = texture.getHeight();
+        double s = this.activeAttributes.scale;
         this.activeAttributes.textOffset.offsetForSize(w, h, renderData.offset);
         renderData.unitSquareTransform.setTranslation(
-            renderData.screenPlacePoint.x - renderData.offset.x,
-            renderData.screenPlacePoint.y - renderData.offset.y,
+            renderData.screenPlacePoint.x - renderData.offset.x * s,
+            renderData.screenPlacePoint.y - renderData.offset.y * s,
             renderData.screenPlacePoint.z);
 
         // Apply the label's rotation according to its rotation value and orientation mode. The rotation is applied
@@ -462,7 +463,7 @@ public class Label extends AbstractRenderable implements Highlightable, Movable 
         }
 
         // Apply the label's translation and scale according to its text size.
-        renderData.unitSquareTransform.multiplyByScale(w, h, 1);
+        renderData.unitSquareTransform.multiplyByScale(w * s, h * s, 1);
 
         WWMath.boundingRectForUnitSquare(renderData.unitSquareTransform, renderData.screenBounds);
         if (!rc.frustum.intersectsViewport(renderData.screenBounds)) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
@@ -994,8 +994,8 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
      * @return True if there is a valid label and label attributes.
      */
     protected boolean mustDrawLabel(RenderContext rc) {
-        return this.label != null
-            && !this.label.isEmpty()
+        return this.activeAttributes.drawLabel
+            && this.label != null && !this.label.isEmpty()
             && this.activeAttributes.labelAttributes != null;
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
@@ -60,7 +60,7 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
      */
     protected static final double DEFAULT_EYE_DISTANCE_SCALING_THRESHOLD = 1e6;
 
-    protected static final double DEFAULT_DEPTH_OFFSET = -0.1;
+    protected static final double DEFAULT_DEPTH_OFFSET = -0.03;
 
     private static Vec3 placePoint = new Vec3();
 
@@ -684,8 +684,9 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
 
         // Compute a screen depth offset appropriate for the current viewing parameters.
         double depthOffset = 0;
-        if (this.cameraDistance < rc.horizonDistance) {
-            depthOffset = DEFAULT_DEPTH_OFFSET;
+        double absTilt = Math.abs( rc.camera.tilt );
+        if (this.cameraDistance < rc.horizonDistance && absTilt <= 90) {
+            depthOffset = ( 1 - absTilt / 90 ) * DEFAULT_DEPTH_OFFSET;
         }
 
         // Project the placemark's model point to screen coordinates, using the screen depth offset to push the screen

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
@@ -49,8 +49,10 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
          * @param rc             The current render context
          * @param placemark      The placemark needing a level of detail selection
          * @param cameraDistance The distance from the placemark to the camera (meters)
+         *
+         * @return if placemark should display or skip its rendering
          */
-        void selectLevelOfDetail(RenderContext rc, Placemark placemark, double cameraDistance);
+        boolean selectLevelOfDetail(RenderContext rc, Placemark placemark, double cameraDistance);
     }
 
     /**
@@ -702,8 +704,9 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
         }
 
         // Allow the placemark to adjust the level of detail based on distance to the camera
-        if (this.levelOfDetailSelector != null) {
-            this.levelOfDetailSelector.selectLevelOfDetail(rc, this, this.cameraDistance);
+        if (this.levelOfDetailSelector != null
+                && !this.levelOfDetailSelector.selectLevelOfDetail(rc, this, this.cameraDistance)) {
+            return; // skip rendering
         }
 
         // Determine the attributes to use for the current render pass.

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/Placemark.java
@@ -840,16 +840,22 @@ public class Placemark extends AbstractRenderable implements Highlightable, Mova
             }
 
             if (this.labelTexture != null) {
+                // Compute an camera-position proximity scaling factor, so that distant placemarks can be scaled smaller than
+                // nearer placemarks.
+                visibilityScale = this.isEyeDistanceScaling() ?
+                        Math.max(this.activeAttributes.minimumImageScale, Math.min(1, this.getEyeDistanceScalingLabelThreshold() / this.cameraDistance)) : 1;
+
                 int w = this.labelTexture.getWidth();
                 int h = this.labelTexture.getHeight();
+                double s = this.activeAttributes.labelAttributes.scale * visibilityScale;
                 this.activeAttributes.labelAttributes.textOffset.offsetForSize(w, h, offset);
 
                 labelTransform.setTranslation(
-                        screenPlacePoint.x - offset.x,
-                        screenPlacePoint.y - offset.y,
+                        screenPlacePoint.x - offset.x * s,
+                        screenPlacePoint.y - offset.y * s,
                         screenPlacePoint.z);
 
-                labelTransform.setScale(w, h, 1);
+                labelTransform.setScale(w * s, h * s, 1);
 
                 WWMath.boundingRectForUnitSquare(labelTransform, labelBounds);
                 if (rc.frustum.intersectsViewport(labelBounds)) {

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/PlacemarkAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/PlacemarkAttributes.java
@@ -306,7 +306,7 @@ public class PlacemarkAttributes {
     /**
      * Returns the attributes to apply to the placemark's label, if any. If null, the placemark's label is not drawn.
      */
-    public Object getLabelAttributes() {
+    public TextAttributes getLabelAttributes() {
         return labelAttributes;
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/PlacemarkAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/PlacemarkAttributes.java
@@ -25,6 +25,8 @@ public class PlacemarkAttributes {
 
     protected double minimumImageScale;
 
+    protected boolean drawLabel;
+
     protected boolean drawLeader;
 
     protected boolean depthTest;
@@ -43,6 +45,7 @@ public class PlacemarkAttributes {
         this.imageOffset = Offset.center();
         this.imageScale = 1;
         this.minimumImageScale = 0;
+        this.drawLabel = true;
         this.drawLeader = false;
         this.depthTest = true;
         this.labelAttributes = new TextAttributes();
@@ -68,6 +71,7 @@ public class PlacemarkAttributes {
         this.imageOffset = new Offset(attributes.imageOffset);
         this.imageScale = attributes.imageScale;
         this.minimumImageScale = attributes.minimumImageScale;
+        this.drawLabel = attributes.drawLabel;
         this.drawLeader = attributes.drawLeader;
         this.depthTest = attributes.depthTest;
         this.labelAttributes = attributes.labelAttributes != null ? new TextAttributes(attributes.labelAttributes) : null;
@@ -85,6 +89,7 @@ public class PlacemarkAttributes {
         this.imageOffset.set(attributes.imageOffset);
         this.imageScale = attributes.imageScale;
         this.minimumImageScale = attributes.minimumImageScale;
+        this.drawLabel = attributes.drawLabel;
         this.drawLeader = attributes.drawLeader;
         this.depthTest = attributes.depthTest;
 
@@ -135,6 +140,7 @@ public class PlacemarkAttributes {
             && this.imageOffset.equals(that.imageOffset)
             && this.imageScale == that.imageScale
             && this.minimumImageScale == that.minimumImageScale
+            && this.drawLabel == that.drawLabel
             && this.drawLeader == that.drawLeader
             && this.depthTest == that.depthTest
             && ((this.labelAttributes == null) ? (that.labelAttributes == null) : this.labelAttributes.equals(that.labelAttributes))
@@ -152,6 +158,7 @@ public class PlacemarkAttributes {
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         temp = Double.doubleToLongBits(this.minimumImageScale);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + (this.drawLabel ? 1 : 0);
         result = 31 * result + (this.drawLeader ? 1 : 0);
         result = 31 * result + (this.depthTest ? 1 : 0);
         result = 31 * result + (this.labelAttributes != null ? this.labelAttributes.hashCode() : 0);
@@ -260,6 +267,23 @@ public class PlacemarkAttributes {
      */
     public PlacemarkAttributes setMinimumImageScale(double minimumImageScale) {
         this.minimumImageScale = minimumImageScale;
+        return this;
+    }
+
+    /**
+     * Returns whether to draw a placemark's label.
+     */
+    public boolean isDrawLabel() {
+        return drawLabel;
+    }
+
+    /**
+     * Sets whether to draw a placemark's label.
+     *
+     * @param drawLabel The new draw label setting.
+     */
+    public PlacemarkAttributes setDrawLabel(boolean drawLabel) {
+        this.drawLabel = drawLabel;
         return this;
     }
 

--- a/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
+++ b/worldwind/src/main/java/gov/nasa/worldwind/shape/TextAttributes.java
@@ -32,6 +32,8 @@ public class TextAttributes {
 
     protected float outlineWidth;
 
+    protected double scale;
+
     public TextAttributes() {
         this.textColor = new Color(1, 1, 1, 1);
         this.textOffset = Offset.bottomCenter();
@@ -41,6 +43,7 @@ public class TextAttributes {
         this.outlineColor = new Color(0, 0, 0, 1);
         this.enableDepthTest = true;
         this.outlineWidth = 3;
+        this.scale = 1;
     }
 
     public TextAttributes(TextAttributes attributes) {
@@ -57,6 +60,7 @@ public class TextAttributes {
         this.enableOutline = attributes.enableOutline;
         this.enableDepthTest = attributes.enableDepthTest;
         this.outlineWidth = attributes.outlineWidth;
+        this.scale = attributes.scale;
     }
 
     public TextAttributes set(TextAttributes attributes) {
@@ -73,6 +77,7 @@ public class TextAttributes {
         this.outlineColor.set(attributes.outlineColor);
         this.enableDepthTest = attributes.enableDepthTest;
         this.outlineWidth = attributes.outlineWidth;
+        this.scale = attributes.scale;
 
         return this;
     }
@@ -94,7 +99,8 @@ public class TextAttributes {
             && this.enableOutline == that.enableOutline
             && this.outlineColor.equals(that.outlineColor)
             && this.enableDepthTest == that.enableDepthTest
-            && this.outlineWidth == that.outlineWidth;
+            && this.outlineWidth == that.outlineWidth
+            && this.scale == that.scale;
     }
 
     @Override
@@ -107,6 +113,8 @@ public class TextAttributes {
         result = 31 * result + this.outlineColor.hashCode();
         result = 31 * result + (this.enableDepthTest ? 1 : 0);
         result = 31 * result + (this.outlineWidth != +0.0f ? Float.floatToIntBits(this.outlineWidth) : 0);
+        long temp = Double.doubleToLongBits(this.scale);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         return result;
     }
 
@@ -194,6 +202,15 @@ public class TextAttributes {
 
     public TextAttributes setOutlineWidth(float lineWidth) {
         this.outlineWidth = lineWidth;
+        return this;
+    }
+
+    public double getScale() {
+        return this.scale;
+    }
+
+    public TextAttributes setScale(double scale) {
+        this.scale = scale;
         return this;
     }
 }


### PR DESCRIPTION
### Description of the Change
1) Change order of unitSquareTransform matrix operations to fix image stretching on rotation and apply correct pivot point. Original code stretched texture instead of rotation and made rotation around texture center instead of specified offset point.
2) Normalize unitSquareTransform matrix Z-range to prevent texture clipping on tilting. Original code had incorrect tilting approach.
3) Change Placemark default depth offset from -0.1 to -0.015 to prevent texture from protruding through the terrain.
4) Fix placemarks altitude mode in PlacemarksMilStd2525Activity to be correctly rendered on the top of the surface. Original code had absolute 0 altitude which was under the surface.
5) Use billboarding approach of MilStd2525 placemarks rendering to prevent clipping them by terrain (as described in MIL-STD-2525C APPENDIX F.5.1.1.2).
6) Add missed Placemark label functionality the same way as in JS codebase.

### Why Should This Be In Core?
Original code had incorrect placemark orientation processing logic and should be fixed.

### Benefits
Now Placemarks are correctly rotated, tilted and located related to the terrain.
Partially implemented Placemark label code is now complete and can be used.

### Potential Drawbacks
None

### Applicable Issues
https://github.com/WorldWindEarth/WorldWindAndroid/issues/31